### PR TITLE
Fix (app/build.gradle): correct NewPipeExtractor dependency string

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -210,5 +210,5 @@ dependencies {
     implementation 'androidx.compose.material3:material3-android:1.2.1'
     implementation "io.noties.markwon:core:4.6.2"
     implementation("org.greenrobot:eventbus:3.3.1")
-    implementation("com.github.teamnewpipe:NewPipeExtractor:0.24.2")
+    implementation("com.github.teamnewpipe:newpipeextractor:0.24.2")
 }


### PR DESCRIPTION
Gradle build was failing due to the NewPipeExtractor dependency being written in pascal case. Changed it to lowercase ('newpipeextractor') according to the TeamNewPipe website [here](https://jitpack.io/p/teamnewpipe/newpipeextractor).