### PR TITLE
Fix preview seek times in cut mode

### DIFF
--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/CutVideoBottomSheetDialog.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/CutVideoBottomSheetDialog.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.*
+import kotlin.math.max
 
 
 class CutVideoBottomSheetDialog(private val _item: DownloadItem? = null, private val urls : String? = null, private var chapters: List<ChapterItem>? = null, private val listener: VideoCutListener? = null) : BottomSheetDialogFragment() {
@@ -453,10 +454,7 @@ class CutVideoBottomSheetDialog(private val _item: DownloadItem? = null, private
         val startTimestampString = startTimestamp.toStringTimeStamp()
         val endTimestampString = endTimestamp.toStringTimeStamp()
 
-        var draggedFromBeginning = true
-        if (toTextInput.text.toString() != endTimestampString){
-            draggedFromBeginning = false
-        }
+        val draggedFromBeginning = rangeSlider.focusedThumbIndex != 1
 
         fromTextInput.setTextAndRecalculateWidth(startTimestampString)
         toTextInput.setTextAndRecalculateWidth(endTimestampString)
@@ -464,14 +462,11 @@ class CutVideoBottomSheetDialog(private val _item: DownloadItem? = null, private
 
         okBtn.isEnabled = values[0] != 0F || values[1] != (itemDurationTimestamp / 1000).toFloat()
 
-        val startpos = startTimestamp * 1000
         try {
             if (draggedFromBeginning){
-                player.seekTo(startpos)
+                player.seekTo(startTimestamp)
             }else{
-                var endpos = (endTimestamp * 1000) - 1500
-                if (endpos < (startTimestamp * 1000)) endpos = startpos
-                player.seekTo(endpos)
+                player.seekTo(max(startTimestamp, endTimestamp - 1500))
             }
             player.play()
         }catch (ignored: Exception) {}


### PR DESCRIPTION
On changing the cut-from and cut-to times using the RangeSlider, the player seeks to the cut-from time or 1.5s before the cut-to time. However, the seek timestamps ([already in milliseconds](https://github.com/deniscerri/ytdlnis/pull/728/files#diff-db7951c7dbfbeb60a61b6f31f3e8017216bf5efb7d26c31edd88c2597c7f09eeL450)) were multiplied with 1000 another time, resulting in the preview seeking to the end of the video and restarting from the cut-from time.

Also, I have changed the detection whether the cut-from or cut-to slider was dragged to use `rangeSlider.focusedThumbIndex` which to me seems more straightforward than comparing the textinput contents. This should also fix the edge case when the cut-to slider is dragged, but ends up in the exact same time as when it started.