### PR TITLE
Disable cut for live videos

### DIFF
--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
@@ -338,7 +338,7 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
                                     val snack = Snackbar.make(view, context.getString(R.string.please_wait), Snackbar.LENGTH_SHORT)
                                     snack.show()
                                 }else if (downloadItem.duration=="0:00"){
-                                    val snack = Snackbar.make(view, context.getString(R.string.cut_live_unsupported), Snackbar.LENGTH_SHORT)
+                                    val snack = Snackbar.make(view, context.getString(R.string.cut_unsupported), Snackbar.LENGTH_SHORT)
                                     snack.show()
                                 }else if (!nonSpecific){
                                     val snack = Snackbar.make(view, context.getString(R.string.cut_unavailable), Snackbar.LENGTH_SHORT)

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
@@ -337,7 +337,7 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
                                 if(isUpdatingData){
                                     val snack = Snackbar.make(view, context.getString(R.string.please_wait), Snackbar.LENGTH_SHORT)
                                     snack.show()
-                                }else if (downloadItem.duration=="0:00"){
+                                }else if (downloadItem.duration == "0:00" || downloadItem.duration == "-1"){
                                     val snack = Snackbar.make(view, context.getString(R.string.cut_unsupported), Snackbar.LENGTH_SHORT)
                                     snack.show()
                                 }else if (!nonSpecific){

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
@@ -337,6 +337,9 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
                                 if(isUpdatingData){
                                     val snack = Snackbar.make(view, context.getString(R.string.please_wait), Snackbar.LENGTH_SHORT)
                                     snack.show()
+                                }else if (downloadItem.duration=="0:00"){
+                                    val snack = Snackbar.make(view, context.getString(R.string.cut_live_unsupported), Snackbar.LENGTH_SHORT)
+                                    snack.show()
                                 }else if (!nonSpecific){
                                     val snack = Snackbar.make(view, context.getString(R.string.cut_unavailable), Snackbar.LENGTH_SHORT)
                                     snack.setAction(R.string.update){

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
@@ -341,7 +341,7 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
                                     val snack = Snackbar.make(view, context.getString(R.string.cut_unsupported), Snackbar.LENGTH_SHORT)
                                     snack.show()
                                 }else if (!nonSpecific){
-                                    val snack = Snackbar.make(view, context.getString(R.string.cut_unavailable), Snackbar.LENGTH_SHORT)
+                                    val snack = Snackbar.make(view, context.getString(R.string.cut_unavailable_please_update_item), Snackbar.LENGTH_SHORT)
                                     snack.setAction(R.string.update){
                                         CoroutineScope(SupervisorJob()).launch(Dispatchers.IO) {
                                             resultItem?.apply {

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadVideoFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadVideoFragment.kt
@@ -367,7 +367,7 @@ class DownloadVideoFragment(private var resultItem: ResultItem? = null, private 
                                 if(isUpdatingData){
                                     val snack = Snackbar.make(view, context.getString(R.string.please_wait), Snackbar.LENGTH_SHORT)
                                     snack.show()
-                                }else if (downloadItem.duration=="0:00"){
+                                }else if (downloadItem.duration == "0:00" || downloadItem.duration == "-1"){
                                     val snack = Snackbar.make(view, context.getString(R.string.cut_unsupported), Snackbar.LENGTH_SHORT)
                                     snack.show()
                                 }else if (!nonSpecific){

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadVideoFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadVideoFragment.kt
@@ -371,7 +371,7 @@ class DownloadVideoFragment(private var resultItem: ResultItem? = null, private 
                                     val snack = Snackbar.make(view, context.getString(R.string.cut_unsupported), Snackbar.LENGTH_SHORT)
                                     snack.show()
                                 }else if (!nonSpecific){
-                                    val snack = Snackbar.make(view, context.getString(R.string.cut_unavailable), Snackbar.LENGTH_SHORT)
+                                    val snack = Snackbar.make(view, context.getString(R.string.cut_unavailable_please_update_item), Snackbar.LENGTH_SHORT)
                                     snack.setAction(R.string.update){
                                         CoroutineScope(SupervisorJob()).launch(Dispatchers.IO) {
                                             resultItem?.apply {

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadVideoFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadVideoFragment.kt
@@ -367,6 +367,9 @@ class DownloadVideoFragment(private var resultItem: ResultItem? = null, private 
                                 if(isUpdatingData){
                                     val snack = Snackbar.make(view, context.getString(R.string.please_wait), Snackbar.LENGTH_SHORT)
                                     snack.show()
+                                }else if (downloadItem.duration=="0:00"){
+                                    val snack = Snackbar.make(view, context.getString(R.string.cut_live_unsupported), Snackbar.LENGTH_SHORT)
+                                    snack.show()
                                 }else if (!nonSpecific){
                                     val snack = Snackbar.make(view, context.getString(R.string.cut_unavailable), Snackbar.LENGTH_SHORT)
                                     snack.setAction(R.string.update){

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadVideoFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadVideoFragment.kt
@@ -368,7 +368,7 @@ class DownloadVideoFragment(private var resultItem: ResultItem? = null, private 
                                     val snack = Snackbar.make(view, context.getString(R.string.please_wait), Snackbar.LENGTH_SHORT)
                                     snack.show()
                                 }else if (downloadItem.duration=="0:00"){
-                                    val snack = Snackbar.make(view, context.getString(R.string.cut_live_unsupported), Snackbar.LENGTH_SHORT)
+                                    val snack = Snackbar.make(view, context.getString(R.string.cut_unsupported), Snackbar.LENGTH_SHORT)
                                     snack.show()
                                 }else if (!nonSpecific){
                                     val snack = Snackbar.make(view, context.getString(R.string.cut_unavailable), Snackbar.LENGTH_SHORT)

--- a/app/src/main/java/com/deniscerri/ytdl/util/UiUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/UiUtil.kt
@@ -1560,8 +1560,10 @@ object UiUtil {
                 }
             }else{
                 cut.alpha = 0.3f
-                cut.setOnClickListener {
-                    cutDisabledClicked()
+                if (duration != "-1") {
+                    cut.setOnClickListener {
+                        cutDisabledClicked()
+                    }
                 }
             }
         }
@@ -1715,8 +1717,10 @@ object UiUtil {
 
             }else{
                 cut.alpha = 0.3f
-                cut.setOnClickListener {
-                    cutDisabledClicked()
+                if (duration != "-1") {
+                    cut.setOnClickListener {
+                        cutDisabledClicked()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/deniscerri/ytdl/util/UiUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/UiUtil.kt
@@ -1560,10 +1560,8 @@ object UiUtil {
                 }
             }else{
                 cut.alpha = 0.3f
-                if (duration != "-1") {
-                    cut.setOnClickListener {
-                        cutDisabledClicked()
-                    }
+                cut.setOnClickListener {
+                    cutDisabledClicked()
                 }
             }
         }
@@ -1717,10 +1715,8 @@ object UiUtil {
 
             }else{
                 cut.alpha = 0.3f
-                if (duration != "-1") {
-                    cut.setOnClickListener {
-                        cutDisabledClicked()
-                    }
+                cut.setOnClickListener {
+                    cutDisabledClicked()
                 }
             }
         }

--- a/app/src/main/java/com/deniscerri/ytdl/util/UiUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/UiUtil.kt
@@ -1520,8 +1520,8 @@ object UiUtil {
         if (items.size > 1 || items.first().url.isEmpty()) cut.isVisible = false
         else{
             cut.setOnClickListener(null)
-            val invalidDuration = items[0].duration == "-1"
-            if(items[0].duration.isNotEmpty() && !invalidDuration){
+            val duration = items[0].duration
+            if(duration.isNotEmpty() && duration != "-1" && duration != "0:00"){
                 val downloadItem = items[0]
                 cut.alpha = 1f
                 if (downloadItem.downloadSections.isNotBlank()) cut.text = downloadItem.downloadSections
@@ -1560,10 +1560,8 @@ object UiUtil {
                 }
             }else{
                 cut.alpha = 0.3f
-                if (!invalidDuration) {
-                    cut.setOnClickListener {
-                        cutDisabledClicked()
-                    }
+                cut.setOnClickListener {
+                    cutDisabledClicked()
                 }
             }
         }
@@ -1686,8 +1684,8 @@ object UiUtil {
         else{
             cut.setOnClickListener(null)
             val downloadItem = items[0]
-            val invalidDuration = downloadItem.duration == "-1"
-            if (downloadItem.duration.isNotEmpty() && !invalidDuration){
+            val duration = downloadItem.duration
+            if (duration.isNotEmpty() && duration != "-1" && duration != "0:00"){
                 cut.alpha = 1f
                 if (downloadItem.downloadSections.isNotBlank()) cut.text = downloadItem.downloadSections
                 val cutVideoListener = object : VideoCutListener {
@@ -1717,10 +1715,8 @@ object UiUtil {
 
             }else{
                 cut.alpha = 0.3f
-                if (!invalidDuration) {
-                    cut.setOnClickListener {
-                        cutDisabledClicked()
-                    }
+                cut.setOnClickListener {
+                    cutDisabledClicked()
                 }
             }
         }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -327,7 +327,7 @@
     <string name="changelog">سجل التغييرات</string>
     <string name="app">التطبيق</string>
     <string name="source">المصادر</string>
-    <string name="cut_unavailable">تحتاج إلى تحديث بيانات العنصر حتى تتمكن من استخدام ميزة القص</string>
+    <string name="cut_unavailable_please_update_item">تحتاج إلى تحديث بيانات العنصر حتى تتمكن من استخدام ميزة القص</string>
     <string name="changed_path_for_everyone_to">تغيّر مسار تنزيل كل عنصر إلى:</string>
     <string name="multiple_download_card">بطاقة التنزيل المتعدد</string>
     <string name="dismiss">تجاهَل</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -327,7 +327,7 @@
     <string name="changelog">Dəyişiklik jurnalı</string>
     <string name="app">Tətbiq</string>
     <string name="source">Mənbə</string>
-    <string name="cut_unavailable">Kəsmə xüsusiyyətin istifadə etmək üçün element məlumatın yeniləməlisiniz</string>
+    <string name="cut_unavailable_please_update_item">Kəsmə xüsusiyyətin istifadə etmək üçün element məlumatın yeniləməlisiniz</string>
     <string name="changed_path_for_everyone_to">Hər bir elementin yükləmə yeri buna dəyişdirildi:</string>
     <string name="dismiss">Ləğv et</string>
     <string name="all">Hamısı</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -305,7 +305,7 @@
     <string name="modify_download_card">Настройване карта за изтегляне</string>
     <string name="buffer_size">Размер на буфера</string>
     <string name="buffer_size_summary">Размер на буфера за изтегляне, например 1024 или 16K (по подразбиране 1024)</string>
-    <string name="cut_unavailable">Трябва да актуализирате, за да можете да използвате функцията за изрязване</string>
+    <string name="cut_unavailable_please_update_item">Трябва да актуализирате, за да можете да използвате функцията за изрязване</string>
     <string name="changed_path_for_everyone_to">Пътят за изтегляне на всеки елемент е променен на:</string>
     <string name="dismiss">Отхвърляне</string>
     <string name="new_source">Нов източник</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -171,7 +171,7 @@
     <string name="pause">وەستاندن</string>
     <string name="format_order">ڕیزکردنی فۆڕمات</string>
     <string name="fragment_retries">دووبارەکردنەوەی پارچەپارچە</string>
-    <string name="cut_unavailable">پێویستە داتای بابەتەکە نوێ بکەیتەوە بۆ ئەوەی بتوانیت تایبەتمەندی بڕین بەکاربهێنیت</string>
+    <string name="cut_unavailable_please_update_item">پێویستە داتای بابەتەکە نوێ بکەیتەوە بۆ ئەوەی بتوانیت تایبەتمەندی بڕین بەکاربهێنیت</string>
     <string name="copy_log">لەبەرگرتنەوەی تۆمار</string>
     <string name="socks5_proxy">Socks5 پرۆکسی URL</string>
     <string name="edit">دەستکاری</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -143,7 +143,7 @@
     <string name="show_download_card">Zobrazit kartu stahování</string>
     <string name="format_order">Pořadí formátů</string>
     <string name="fragment_retries">Opakování fragmentů</string>
-    <string name="cut_unavailable">Abyste mohli použít funkci střihu, musíte aktualizovat údaje o položce</string>
+    <string name="cut_unavailable_please_update_item">Abyste mohli použít funkci střihu, musíte aktualizovat údaje o položce</string>
     <string name="copy_log">Kopírovat protokol</string>
     <string name="socks5_proxy">Adresa Socks5 Proxy</string>
     <string name="edit">Editovat</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -380,7 +380,7 @@
     <string name="format_smallest">Kleinstes Format (pro Auflösung)</string>
     <string name="retry_missing_downloads">Fehlende Downloads erneut versuchen</string>
     <string name="dismiss">Ablehnen</string>
-    <string name="cut_unavailable">Um das Schnittprogramm nutzen zu können, ist es nötig, zuerst die Daten in die richtige Reihenfolge zu bringen.</string>
+    <string name="cut_unavailable_please_update_item">Um das Schnittprogramm nutzen zu können, ist es nötig, zuerst die Daten in die richtige Reihenfolge zu bringen.</string>
     <string name="on_time">Zum Zeitpunkt</string>
     <string name="display_over_apps_summary">Downloadkarte immer im Vordergrund anzeigen. Diese Einstellung deaktivieren, falls sich die aktuell laufende App schließt, wenn die Downloadkarte angezeigt wird.</string>
     <string name="minute">Minute</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -354,7 +354,7 @@
     <string name="multiple_download_card">Πολλαπλή κάρτα λήψης</string>
     <string name="format_filter">Φίλτρο μορφής</string>
     <string name="format_smallest">Μικρότερη μορφή (ανά ανάλυση)</string>
-    <string name="cut_unavailable">Πρέπει να ενημερώσετε τα δεδομένα του στοιχείου για να μπορέσετε να χρησιμοποιήσετε τη λειτουργία αποκοπής</string>
+    <string name="cut_unavailable_please_update_item">Πρέπει να ενημερώσετε τα δεδομένα του στοιχείου για να μπορέσετε να χρησιμοποιήσετε τη λειτουργία αποκοπής</string>
     <string name="cache_first_summary">Τα αρχεία της προσωρινής μνήμης κατεβαίνουν στον εσωτερικό αποθηκευτικό χώρο και στη συνέχεια μεταφέρονται στον επιλεγμένο κατάλογο. Χρησιμοποιήστε το όταν δεν μπορείτε να γράψετε απευθείας στον αποθηκευτικό χώρο</string>
     <string name="update_app_beta_summary">Εγγραφείτε στο πρόγραμμα beta. Μπορεί να περιέχει σφάλματα.</string>
     <string name="security">Ασφάλεια</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -327,7 +327,7 @@
     <string name="changelog">Registro de cambios</string>
     <string name="app">Aplicación</string>
     <string name="source">Fuente</string>
-    <string name="cut_unavailable">Debes actualizar los datos del artículo para poder utilizar la función de corte</string>
+    <string name="cut_unavailable_please_update_item">Debes actualizar los datos del artículo para poder utilizar la función de corte</string>
     <string name="changed_path_for_everyone_to">Cambiada la ruta de descarga de cada elemento a:</string>
     <string name="dismiss">Descartar</string>
     <string name="all">Todos</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -345,7 +345,7 @@
     <string name="save_auto_subs">Enregistrer les sous-titres automatiques</string>
     <string name="not_deleted">Non supprimé</string>
     <string name="on_time">Sur</string>
-    <string name="cut_unavailable">Vous devez mettre à jour les données de l\'élément pour utiliser la fonction de coupe.</string>
+    <string name="cut_unavailable_please_update_item">Vous devez mettre à jour les données de l\'élément pour utiliser la fonction de coupe.</string>
     <string name="format_smallest">Le plus petit format
 \n(par résolution)</string>
     <string name="confirm_delete_sources_desc">Supprimer définitivement

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -327,7 +327,7 @@
     <string name="changelog">चैंजलॉग</string>
     <string name="app">ऐप</string>
     <string name="source">स्रोत</string>
-    <string name="cut_unavailable">कट सुविधा का उपयोग करने में सक्षम होने के लिए आपको आइटम डेटा को अपडेट करना होगा</string>
+    <string name="cut_unavailable_please_update_item">कट सुविधा का उपयोग करने में सक्षम होने के लिए आपको आइटम डेटा को अपडेट करना होगा</string>
     <string name="changed_path_for_everyone_to">प्रत्येक आइटम के डाउनलोड पथ को इसमें बदल दिया:</string>
     <string name="dismiss">ख़ारिज करें</string>
     <string name="all">सभी</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -334,7 +334,7 @@
     <string name="multiple_download_card">Többszörös letöltési kártya</string>
     <string name="format_filter">Formátum szűrő</string>
     <string name="format_smallest">Legkisebb formátum (felbontásonként)</string>
-    <string name="cut_unavailable">A vágási funkció használatához frissítenie kell az elemadatokat</string>
+    <string name="cut_unavailable_please_update_item">A vágási funkció használatához frissítenie kell az elemadatokat</string>
     <string name="observe_sources">Források megfigyelése</string>
     <string name="new_source">Új forrás</string>
     <string name="delete_all_sources">Minden forrás törlése</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -357,7 +357,7 @@
     <string name="multiple_download_card">Beberapa Kartu Unduhan</string>
     <string name="format_filter">Format Penyaring</string>
     <string name="format_smallest">Format terkecil (per Resolusi)</string>
-    <string name="cut_unavailable">Kamu perlu memutakhirkan data butir agar bisa menggunakan fitur pemotongan</string>
+    <string name="cut_unavailable_please_update_item">Kamu perlu memutakhirkan data butir agar bisa menggunakan fitur pemotongan</string>
     <string name="no_download_fragments">Jangan unduh sebagai Fragmen</string>
     <string name="wrap_text">Bungkus Teks</string>
     <string name="swipe_gestures_download_card">Gestur Usap di kartu unduhan</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -334,7 +334,7 @@
     <string name="multiple_download_card">Scheda download multipla</string>
     <string name="format_filter">Formato del filtro</string>
     <string name="format_smallest">Formato più piccolo (per Risoluzione)</string>
-    <string name="cut_unavailable">È necessario aggiornare i dati dell\'articolo per poter utilizzare la funzione di taglio</string>
+    <string name="cut_unavailable_please_update_item">È necessario aggiornare i dati dell\'articolo per poter utilizzare la funzione di taglio</string>
     <string name="delete_all_sources">Cancella Tutti i Sorgenti</string>
     <string name="force_ipv4_desc">Esegui tutti le connessioni usando IPv4</string>
     <string name="force_ipv4">Forza IPv4</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -408,7 +408,7 @@
     <string name="multiple_download_card">כרטיס הורדה מרובה</string>
     <string name="format_filter">פורמט מסנן</string>
     <string name="format_smallest">הפורמט הקטן היותר (לכל רזולוציה)</string>
-    <string name="cut_unavailable">עליך לעדכן את נתוני הפריט כדי שתוכל להשתמש בתכונת החיתוך</string>
+    <string name="cut_unavailable_please_update_item">עליך לעדכן את נתוני הפריט כדי שתוכל להשתמש בתכונת החיתוך</string>
     <string name="use_item_url_not_playlist">השתמש בקישור של פריט במקום בקישור של רשימת ההשמעה</string>
     <string name="recode_video_summary">מקודד מחדש את קובץ הוידאו לפורמט הוידאו שצוין</string>
     <string name="recode_video">קודד מחדש את הוידאו</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -327,7 +327,7 @@
     <string name="changelog">更新履歴</string>
     <string name="app">アプリ</string>
     <string name="source">取得元</string>
-    <string name="cut_unavailable">カット機能を使うにはこの項目のデータを更新する必要があります</string>
+    <string name="cut_unavailable_please_update_item">カット機能を使うにはこの項目のデータを更新する必要があります</string>
     <string name="dismiss">非表示</string>
     <string name="all">すべて</string>
     <string name="multiple_download_card">複数ダウンロードの画面</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -370,7 +370,7 @@
     <string name="multiple_download_card">여러 다운로드 카드</string>
     <string name="format_filter">포맷 필터</string>
     <string name="format_smallest">가장 작은 포맷 (해상도 단위)</string>
-    <string name="cut_unavailable">컷 기능을 사용하기 위해 항목 데이터를 업데이트해야 합니다</string>
+    <string name="cut_unavailable_please_update_item">컷 기능을 사용하기 위해 항목 데이터를 업데이트해야 합니다</string>
     <string name="my_filename_templates">내 파일 이름 템플릿</string>
     <string name="prefer_smaller_formats">파일 크기가 더 작은 형식을 선호합니다</string>
     <string name="display_over_apps">앱 위에 표시</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -387,7 +387,7 @@
     <string name="use_extra_commands_summary">Voor audio-/video­downloads. Voeg extra opdrachten toe samen met de GUI-configuratie</string>
     <string name="piped_instance_summary">Voer een Piped-API-server in die de app kan gebruiken voor YouTube-query\'s en -indelingen</string>
     <string name="changed_path_for_everyone_to">Download­pad van alle items aangepast naar:</string>
-    <string name="cut_unavailable">U moet de item­gegevens bĳwerken om de knip­functie te kunnen gebruiken</string>
+    <string name="cut_unavailable_please_update_item">U moet de item­gegevens bĳwerken om de knip­functie te kunnen gebruiken</string>
     <string name="audio_only_item">Dit item bevat enkel audio­formaten</string>
     <string name="force_keyframes_summary">Langzamer proces, maar preciezere sneden</string>
     <string name="download_already_exists_summary">Wilt u nog steeds downloaden?</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -327,7 +327,7 @@
     <string name="changelog">ਚੇਂਜਲੌਗ</string>
     <string name="app">ਐਪ</string>
     <string name="source">ਸ੍ਰੋਤ</string>
-    <string name="cut_unavailable">ਕੱਟ ਫੀਚਰ ਦੀ ਵਰਤੋਂ ਕਰਨ ਦੇ ਯੋਗ ਹੋਣ ਲਈ ਤੁਹਾਨੂੰ ਆਈਟਮ ਡੇਟਾ ਨੂੰ ਅਪਡੇਟ ਕਰਨ ਦੀ ਲੋੜ ਹੈ</string>
+    <string name="cut_unavailable_please_update_item">ਕੱਟ ਫੀਚਰ ਦੀ ਵਰਤੋਂ ਕਰਨ ਦੇ ਯੋਗ ਹੋਣ ਲਈ ਤੁਹਾਨੂੰ ਆਈਟਮ ਡੇਟਾ ਨੂੰ ਅਪਡੇਟ ਕਰਨ ਦੀ ਲੋੜ ਹੈ</string>
     <string name="format_filter">ਫਾਰਮੈਟ ਫਿਲਟਰ</string>
     <string name="changed_path_for_everyone_to">ਹਰ ਆਈਟਮ ਦੇ ਡਾਊਨਲੋਡ ਮਾਰਗ ਨੂੰ ਇਸ ਵਿੱਚ ਬਦਲਿਆ:</string>
     <string name="dismiss">ਖਾਰਿਜ ਕਰੋ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -334,7 +334,7 @@
     <string name="multiple_download_card">Karta wielokrotnego pobierania</string>
     <string name="format_filter">Format filtra</string>
     <string name="format_smallest">Najmniejszy format (według rozdzielczości)</string>
-    <string name="cut_unavailable">Musisz zaktualizować dane elementu, aby móc korzystać z funkcji cięcia</string>
+    <string name="cut_unavailable_please_update_item">Musisz zaktualizować dane elementu, aby móc korzystać z funkcji cięcia</string>
     <string name="observe_sources">Obserwuj źródła</string>
     <string name="new_source">Nowe źródło</string>
     <string name="confirm_delete_sources_desc">Usuń trwale wszystkie źródła</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -327,7 +327,7 @@
     <string name="changelog">Histórico de atualização</string>
     <string name="app">Aplicativo</string>
     <string name="source">Origem</string>
-    <string name="cut_unavailable">É necessário atualizar os dados do item para poder utilizar a função de corte</string>
+    <string name="cut_unavailable_please_update_item">É necessário atualizar os dados do item para poder utilizar a função de corte</string>
     <string name="changed_path_for_everyone_to">Caminho de download de cada item alterado para:</string>
     <string name="format_smallest">Menor formato (por resolução)</string>
     <string name="dismiss">Descartar</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -327,7 +327,7 @@
     <string name="changelog">Registo de alterações</string>
     <string name="app">Aplicação</string>
     <string name="source">Fonte</string>
-    <string name="cut_unavailable">Tem que atualizar os dados do item para poder utilizar a função de corte</string>
+    <string name="cut_unavailable_please_update_item">Tem que atualizar os dados do item para poder utilizar a função de corte</string>
     <string name="changed_path_for_everyone_to">Alterado o caminho da descarga de cada item para:</string>
     <string name="dismiss">Rejeitar</string>
     <string name="all">Tudo</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -387,7 +387,7 @@
     <string name="all">Toate</string>
     <string name="generic">Generic</string>
     <string name="format_filter">Filtru de format</string>
-    <string name="cut_unavailable">Trebuie să actualizați datele articolului pentru a putea folosi funcția de tăiere</string>
+    <string name="cut_unavailable_please_update_item">Trebuie să actualizați datele articolului pentru a putea folosi funcția de tăiere</string>
     <string name="always">Mereu</string>
     <string name="label_visibility">Vizibilitate Etichete</string>
     <string name="reset">Resetare</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -327,7 +327,7 @@
     <string name="changelog">Список изменений</string>
     <string name="app">Приложение</string>
     <string name="source">Источник</string>
-    <string name="cut_unavailable">Вам необходимо обновить данные элемента, чтобы иметь возможность использовать функцию резки</string>
+    <string name="cut_unavailable_please_update_item">Вам необходимо обновить данные элемента, чтобы иметь возможность использовать функцию резки</string>
     <string name="changed_path_for_everyone_to">Изменен путь загрузки каждого элемента на:</string>
     <string name="all">Все</string>
     <string name="generic">Общий</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -320,7 +320,7 @@
     <string name="update_ytdl_stable">Stabilná verzia yt-dlp</string>
     <string name="force_keyframes_summary">Pomalší proces, ale presnejšie orezania</string>
     <string name="changelog">Zoznam zmien</string>
-    <string name="cut_unavailable">Aby ste mohli použiť funkciu orezania, musíte aktualizovať údaje o položke</string>
+    <string name="cut_unavailable_please_update_item">Aby ste mohli použiť funkciu orezania, musíte aktualizovať údaje o položke</string>
     <string name="app">Aplikácia</string>
     <string name="modify_download_card">Upraviť kartu sťahovania</string>
     <string name="source">Zdroj</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -327,7 +327,7 @@
     <string name="changelog">Ndryshimet</string>
     <string name="app">Aplikacioni</string>
     <string name="source">Burimi</string>
-    <string name="cut_unavailable">Ju duhet të përditësoni të dhënat e artikullit që të përdorni prerjen</string>
+    <string name="cut_unavailable_please_update_item">Ju duhet të përditësoni të dhënat e artikullit që të përdorni prerjen</string>
     <string name="changed_path_for_everyone_to">Direktoria e secilit element u ndryshua tek:</string>
     <string name="dismiss">Hiq</string>
     <string name="all">Të gjitha</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -327,7 +327,7 @@
     <string name="changelog">Евиденција промена</string>
     <string name="app">Апликација</string>
     <string name="source">Извор</string>
-    <string name="cut_unavailable">Морате да ажурирате податке о предмету да бисте могли да користите функцију сечења</string>
+    <string name="cut_unavailable_please_update_item">Морате да ажурирате податке о предмету да бисте могли да користите функцију сечења</string>
     <string name="dismiss">Одбаци</string>
     <string name="changed_path_for_everyone_to">Путања за преузимање свих предмета је промењена у:</string>
     <string name="all">Све</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -358,7 +358,7 @@
     <string name="ends">Slutar</string>
     <string name="after">Efter</string>
     <string name="occurrences">händelser</string>
-    <string name="cut_unavailable">Du måste uppdatera objektdata för att kunna använda klippfunktionen</string>
+    <string name="cut_unavailable_please_update_item">Du måste uppdatera objektdata för att kunna använda klippfunktionen</string>
     <string name="format_filter">Formatfilter</string>
     <string name="format_smallest">Minsta format (per upplösning)</string>
     <string name="starts">Startar</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -204,7 +204,7 @@
     <string name="update_ytdl_master">YT-DLP இன் முதன்மை பதிப்பு</string>
     <string name="changelog">மாற்றபதிவு</string>
     <string name="app">பயன்பாடு</string>
-    <string name="cut_unavailable">வெட்டு அம்சத்தைப் பயன்படுத்த நீங்கள் உருப்படி தரவைப் புதுப்பிக்க வேண்டும்</string>
+    <string name="cut_unavailable_please_update_item">வெட்டு அம்சத்தைப் பயன்படுத்த நீங்கள் உருப்படி தரவைப் புதுப்பிக்க வேண்டும்</string>
     <string name="all">அனைத்தும்</string>
     <string name="generic">பொதுவான</string>
     <string name="format_smallest">மிகச்சிறிய வடிவம் (தீர்மானத்திற்கு)</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -337,7 +337,7 @@
     <string name="multiple_download_card">Çoklu İndirme Kartı</string>
     <string name="format_filter">Format Filtresi</string>
     <string name="format_smallest">En küçük format (Çözünürlük başına)</string>
-    <string name="cut_unavailable">Kesme özelliğini kullanabilmek için öğe verilerini güncellemeniz gerekir</string>
+    <string name="cut_unavailable_please_update_item">Kesme özelliğini kullanabilmek için öğe verilerini güncellemeniz gerekir</string>
     <string name="observe_sources">Kaynakları Gözlemle</string>
     <string name="new_source">Yeni Kaynak</string>
     <string name="delete_all_sources">Bütün Kaynakları Sil</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -327,7 +327,7 @@
     <string name="changelog">Список змін</string>
     <string name="app">Застосунок</string>
     <string name="source">Джерело</string>
-    <string name="cut_unavailable">Вам потрібно оновити дані товару, щоб мати можливість використовувати функцію вирізання</string>
+    <string name="cut_unavailable_please_update_item">Вам потрібно оновити дані товару, щоб мати можливість використовувати функцію вирізання</string>
     <string name="changed_path_for_everyone_to">Змінено шлях завантаження кожного елемента на:</string>
     <string name="dismiss">Відхилити</string>
     <string name="all">Все</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -319,7 +319,7 @@
     <string name="update_ytdl_master">Phiên bản Master của yt-dlp</string>
     <string name="ytdl_source">Nguồn yt-dlp</string>
     <string name="changelog">Nhật ký thay đổi</string>
-    <string name="cut_unavailable">Bạn cần cập nhật dữ liệu để có thể sử dụng tính năng cắt</string>
+    <string name="cut_unavailable_please_update_item">Bạn cần cập nhật dữ liệu để có thể sử dụng tính năng cắt</string>
     <string name="app">Ứng dụng</string>
     <string name="errored_downloads">Tải xuống bị lỗi</string>
     <string name="preferred_audio_language">Ngôn ngữ âm thanh ưa thích</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -327,7 +327,7 @@
     <string name="changelog">更新日志</string>
     <string name="app">应用</string>
     <string name="source">源</string>
-    <string name="cut_unavailable">你需要更新项目数据才能使用剪切功能</string>
+    <string name="cut_unavailable_please_update_item">你需要更新项目数据才能使用剪切功能</string>
     <string name="changed_path_for_everyone_to">已将每个项目的下载路径更改至：</string>
     <string name="dismiss">放弃</string>
     <string name="all">全部</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -325,7 +325,7 @@
     <string name="buffer_size">緩衝區大小</string>
     <string name="update_ytdl_stable">yt-dlp 的穩定版本</string>
     <string name="changelog">更新日誌</string>
-    <string name="cut_unavailable">為了使用剪切功能，您需要更新項目資料</string>
+    <string name="cut_unavailable_please_update_item">為了使用剪切功能，您需要更新項目資料</string>
     <string name="app">應用程式</string>
     <string name="source">來源</string>
     <string name="changed_path_for_everyone_to">將每個項目的下載路徑更改為：</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -330,7 +330,7 @@
     <string name="changelog">Changelog</string>
     <string name="source">Source</string>
     <string name="app">App</string>
-    <string name="cut_unavailable">You need to update the item data in order to be able to use cut feature</string>
+    <string name="cut_unavailable_please_update_item">You need to update the item data in order to be able to use cut feature</string>
     <string name="changed_path_for_everyone_to">Changed every item\'s download path to:</string>
     <string name="dismiss">Dismiss</string>
     <string name="all">All</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -476,5 +476,5 @@
     <string name="regenerate">Re-generate</string>
     <string name="generate_potokens_warning">* By enabling this, you need to disable cookies</string>
     <string name="custom">Custom</string>
-    <string name="cut_live_unsupported">Cutting live videos is not supported</string>
+    <string name="cut_unsupported">Cutting is not available for this item</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -476,4 +476,5 @@
     <string name="regenerate">Re-generate</string>
     <string name="generate_potokens_warning">* By enabling this, you need to disable cookies</string>
     <string name="custom">Custom</string>
+    <string name="cut_live_unsupported">Cutting live videos is not supported</string>
 </resources>


### PR DESCRIPTION
Fixes #801. Greys out the cut button if the duration is `0:00` and on tap shows snackbar "Cutting live videos is not supported".

Another possible approach could be to try to parse the duration as timestamp, and if it does not parse or is 0, disable cutting.

Note that I am not familiar with other reasons for invalid durations such as `-1`.


