### PR TITLE
Disable build on PRs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,8 +10,6 @@ permissions:
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
PR builds seem to fail due to missing signing config (and I'm getting an email every time):

for instance [here](https://github.com/deniscerri/ytdlnis/actions/runs/15055387255/job/42319997635#step:11:25):

```
 FAILURE: Build failed with an exception.

* Where:
Build file '/home/runner/work/ytdlnis/ytdlnis/app/build.gradle' line: 38


Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
* What went wrong:
A problem occurred evaluating project ':app'.
> path may not be null or empty string. path='null'
```

and in [app/build.gradle, line: 38](https://github.com/deniscerri/ytdlnis/blob/main/app/build.gradle#L38):

```gradle
signingConfigs {
  debug {
    storeFile file(properties["signingConfig.storeFile"]) // <-- line 38
    storePassword properties["signingConfig.storePassword"]
    keyAlias properties["signingConfig.keyAlias"]
    keyPassword properties["signingConfig.keyPassword"]
  }
}
```