### PR TITLE
twitch supportV2 : can download twitch videos without sub

### DIFF
--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
@@ -64,10 +64,7 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
     lateinit var title : TextInputLayout
     lateinit var author : TextInputLayout
     lateinit var preferences: SharedPreferences
-    private lateinit var shownFields: List<String>
-
-    private var disabledCutClicked: Boolean = false
-
+    lateinit var shownFields: List<String>
     @SuppressLint("RestrictedApi")
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -337,17 +334,13 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
                                 if(isUpdatingData){
                                     val snack = Snackbar.make(view, context.getString(R.string.please_wait), Snackbar.LENGTH_SHORT)
                                     snack.show()
-                                }else if (downloadItem.duration == "0:00" || downloadItem.duration == "-1"){
-                                    val snack = Snackbar.make(view, context.getString(R.string.cut_unsupported), Snackbar.LENGTH_SHORT)
-                                    snack.show()
                                 }else if (!nonSpecific){
-                                    val snack = Snackbar.make(view, context.getString(R.string.cut_unavailable_please_update_item), Snackbar.LENGTH_SHORT)
+                                    val snack = Snackbar.make(view, context.getString(R.string.cut_unavailable), Snackbar.LENGTH_SHORT)
                                     snack.setAction(R.string.update){
                                         CoroutineScope(SupervisorJob()).launch(Dispatchers.IO) {
                                             resultItem?.apply {
                                                 val rsVM = ViewModelProvider(requireActivity())[ResultViewModel::class.java]
                                                 rsVM.updateItemData(this)
-                                                disabledCutClicked = true
                                             }
                                         }
                                     }
@@ -382,12 +375,6 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
                 e.printStackTrace()
             }
             super.onViewCreated(view, savedInstanceState)
-
-            view.findViewById<Chip>(R.id.cut).apply {
-                if (this.isEnabled && savedInstanceState?.containsKey("click_cut") == true) {
-                    this.performClick()
-                }
-            }
         }
     }
 
@@ -414,10 +401,6 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
         resultItem = res
         val state = Bundle()
         state.putBoolean("updated", true)
-        if (disabledCutClicked) {
-            state.putBoolean("click_cut", true)
-            disabledCutClicked = false
-        }
         onViewCreated(requireView(),savedInstanceState = state)
     }
 

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadVideoFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadVideoFragment.kt
@@ -37,7 +37,6 @@ import com.deniscerri.ytdl.util.FileUtil
 import com.deniscerri.ytdl.util.FormatUtil
 import com.deniscerri.ytdl.util.UiUtil
 import com.google.android.material.card.MaterialCardView
-import com.google.android.material.chip.Chip
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.TextInputLayout
 import com.google.android.material.textfield.TextInputLayout.END_ICON_CUSTOM
@@ -68,8 +67,6 @@ class DownloadVideoFragment(private var resultItem: ResultItem? = null, private 
     private lateinit var genericAudioFormats: MutableList<Format>
 
     lateinit var downloadItem: DownloadItem
-
-    private var disabledCutClicked: Boolean = false
 
 
     @SuppressLint("RestrictedApi")
@@ -367,17 +364,13 @@ class DownloadVideoFragment(private var resultItem: ResultItem? = null, private 
                                 if(isUpdatingData){
                                     val snack = Snackbar.make(view, context.getString(R.string.please_wait), Snackbar.LENGTH_SHORT)
                                     snack.show()
-                                }else if (downloadItem.duration == "0:00" || downloadItem.duration == "-1"){
-                                    val snack = Snackbar.make(view, context.getString(R.string.cut_unsupported), Snackbar.LENGTH_SHORT)
-                                    snack.show()
                                 }else if (!nonSpecific){
-                                    val snack = Snackbar.make(view, context.getString(R.string.cut_unavailable_please_update_item), Snackbar.LENGTH_SHORT)
+                                    val snack = Snackbar.make(view, context.getString(R.string.cut_unavailable), Snackbar.LENGTH_SHORT)
                                     snack.setAction(R.string.update){
                                         CoroutineScope(SupervisorJob()).launch(Dispatchers.IO) {
                                             resultItem?.apply {
                                                 val rsVM = ViewModelProvider(requireActivity())[ResultViewModel::class.java]
                                                 rsVM.updateItemData(this)
-                                                disabledCutClicked = true
                                             }
                                         }
                                     }
@@ -451,12 +444,6 @@ class DownloadVideoFragment(private var resultItem: ResultItem? = null, private 
             } catch (e: Exception) {
                 e.printStackTrace()
             }
-
-            view.findViewById<Chip>(R.id.cut).apply {
-                if (this.isEnabled && savedInstanceState?.containsKey("click_cut") == true) {
-                    this.performClick()
-                }
-            }
         }
     }
 
@@ -473,10 +460,6 @@ class DownloadVideoFragment(private var resultItem: ResultItem? = null, private 
         resultItem = res
         val state = Bundle()
         state.putBoolean("updated", true)
-        if (disabledCutClicked) {
-            state.putBoolean("click_cut", true)
-            disabledCutClicked = false
-        }
         onViewCreated(requireView(),savedInstanceState = state)
     }
 

--- a/app/src/main/res/layout/dialog_select_range.xml
+++ b/app/src/main/res/layout/dialog_select_range.xml
@@ -1,0 +1,32 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/start">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/start_edit_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="number" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="@string/end">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/end_edit_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="number" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout> 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -478,4 +478,7 @@
     <string name="custom">Custom</string>
     <string name="cut_unsupported">Cutting is not available for this item</string>
     <string name="select_between_desc">Specify the range of items to select</string>
+    <string name="cut_unavailable">Video cut is unavailable for this item</string>
+    <string name="select_range">Select range</string>
+    <string name="invalid_range">Invalid range</string>
 </resources>


### PR DESCRIPTION
This pull request introduces support for downloading Twitch VODs, including those from non-subscribed channels, by finding a direct M3U8 link.

Problem:
Standard yt-dlp often fails to download Twitch VODs as direct access to streaming manifests is restricted. This is especially true for VODs from channels the user is not subscribed to.

Solution:
This implementation circumvents the issue by using Twitch's internal GraphQL API to fetch video metadata.

How it works:
When a Twitch VOD URL is provided, the app makes a GraphQL query to the Twitch GQL endpoint to retrieve the VOD's metadata.
The response contains a seekPreviewsURL, which is a template for storyboard thumbnails. This implementation uses this template URL as a base to construct and validate potential M3U8 playlist URLs.

It iterates through possible resolutions and URL formats until a valid, publicly accessible M3U8 playlist is found.
This direct M3U8 link is then passed to the downloader.

The implementation also extracts the video's title and thumbnail from the GQL response to display them correctly in the UI.
This method allows users to reliably download Twitch VODs that were previously inaccessible, complete with the correct title and thumbnail.

My implementation is obviously not perfect as you can see but you understand the main points and it works very well.

thanks to https://github.com/besuper/TwitchNoSub.git


![Screenshot_2025-06-13-16-51-00-93_2bde0e07fd61d625cf63c538621e2efc](https://github.com/user-attachments/assets/112ad6b4-3f66-4a19-8a48-cc36ebbca9c7)
![Screenshot_2025-06-13-16-51-13-11_2bde0e07fd61d625cf63c538621e2efc](https://github.com/user-attachments/assets/24e5739c-e700-4fca-a241-51bbcdd2afc9)
![Screenshot_2025-06-13-16-51-35-27_2bde0e07fd61d625cf63c538621e2efc](https://github.com/user-attachments/assets/fb80da9c-f5d9-4796-95c1-0aec6aad268a)
