### PR TITLE
Fix mediastore delete

### DIFF
--- a/app/src/main/java/com/deniscerri/ytdl/util/FileUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/FileUtil.kt
@@ -10,6 +10,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.DocumentsContract
+import android.provider.MediaStore
 import android.util.DisplayMetrics
 import android.util.Log
 import android.view.ViewGroup
@@ -63,7 +64,17 @@ object FileUtil {
             if (!File(path).delete()){
                 DocumentFile.fromSingleUri(App.instance, Uri.parse(path))?.delete()
             }
+            deleteFileFromMediaStore(path)
         }
+    }
+
+    private fun deleteFileFromMediaStore(path: String) {
+        val contentResolver = App.instance.contentResolver
+        val file = File(path)
+        val uri = MediaStore.Files.getContentUri("external")
+        val selection = MediaStore.MediaColumns.DATA + " =?"
+        val selectionArgs = arrayOf(file.absolutePath)
+        contentResolver.delete(uri, selection, selectionArgs)
     }
 
     fun exists(path: String) : Boolean {

--- a/app/src/main/java/com/deniscerri/ytdl/util/FileUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/FileUtil.kt
@@ -72,8 +72,24 @@ object FileUtil {
         val contentResolver = App.instance.contentResolver
         val file = File(path)
         val uri = MediaStore.Files.getContentUri("external")
-        val selection = MediaStore.MediaColumns.DATA + " =?"
-        val selectionArgs = arrayOf(file.absolutePath)
+
+        val selection: String
+        val selectionArgs: Array<String>
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val parentPath = file.parentFile?.absolutePath ?: ""
+            val externalStoragePath = Environment.getExternalStorageDirectory().absolutePath
+            val relativePath = if (parentPath.length > externalStoragePath.length && parentPath.startsWith(externalStoragePath)) {
+                parentPath.substring(externalStoragePath.length).removePrefix("/") + "/"
+            } else {
+                ""
+            }
+            selection = MediaStore.MediaColumns.RELATIVE_PATH + " =? AND " + MediaStore.MediaColumns.DISPLAY_NAME + " =?"
+            selectionArgs = arrayOf(relativePath, file.name)
+        } else {
+            selection = MediaStore.MediaColumns.DATA + " =?"
+            selectionArgs = arrayOf(file.absolutePath)
+        }
         contentResolver.delete(uri, selection, selectionArgs)
     }
 


### PR DESCRIPTION
### What this PR does

Fixes an issue where deleted video files remained visible in MediaStore on some Android devices.

### Why it's needed

Previous deletion logic failed to clean up MediaStore entries for files on non-primary volumes, leaving stale references behind.

### Related Issue

Fixes #930