### PR TITLE
Quality: Unsafe `fragmentId!!` and navigation after `recreate()` can crash reset flow

### DIFF
--- a/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/downloading/DownloadSettingsFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/downloading/DownloadSettingsFragment.kt
@@ -1,7 +1,6 @@
 package com.deniscerri.ytdl.ui.more.settings.downloading
 
 import android.os.Bundle
-import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
 import androidx.preference.PreferenceManager
 import com.deniscerri.ytdl.R
@@ -24,9 +23,6 @@ class DownloadSettingsFragment : BaseSettingsFragment() {
             UiUtil.showGenericConfirmDialog(requireContext(), getString(R.string.reset), getString(R.string.reset_preferences_in_screen)) {
                 resetPreferences(editor, preferenceXMLRes)
                 requireActivity().recreate()
-                val fragmentId = findNavController().currentDestination?.id
-                findNavController().popBackStack(fragmentId!!,true)
-                findNavController().navigate(fragmentId)
             }
             true
         }


### PR DESCRIPTION
## Problem

The reset callback force-unwraps `currentDestination?.id` (`fragmentId!!`) and then performs `popBackStack/navigate` immediately after `requireActivity().recreate()`. During/after activity recreation, the fragment/nav state can be detached or `currentDestination` can be null, causing `NullPointerException` or `IllegalStateException` in production when users tap reset.


**Severity**: `high`
**File**: `app/src/main/java/com/deniscerri/ytdl/ui/more/settings/downloading/DownloadSettingsFragment.kt`

## Solution

Do not navigate after `recreate()`, and remove the force unwrap. Replace the callback body with: `resetPreferences(editor, preferenceXMLRes); requireActivity().recreate()`. If navigation is still needed, capture `val fragmentId = findNavController().currentDestination?.id ?: return@showGenericConfirmDialog` before any lifecycle-changing call and avoid `!!`.


## Changes

- `app/src/main/java/com/deniscerri/ytdl/ui/more/settings/downloading/DownloadSettingsFragment.kt` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
