### PR TITLE
Fix settings screen insets on Android 16

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />
 </project>

--- a/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/BaseSettingsFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/BaseSettingsFragment.kt
@@ -3,7 +3,10 @@ package com.deniscerri.ytdl.ui.more.settings
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import android.os.Bundle
+import android.util.Log
 import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
@@ -72,6 +75,22 @@ abstract class BaseSettingsFragment : PreferenceFragmentCompat(), SettingHost {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        ViewCompat.setOnApplyWindowInsetsListener(listView) { v, insets ->
+            val systemBars = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars()
+            )
+
+            v.setPadding(
+                v.paddingLeft,
+                v.paddingTop,
+                v.paddingRight,
+                v.paddingBottom + systemBars.bottom
+            )
+
+            insets
+        }
+
         val keyToHighlight = arguments?.getString("highlight_key")
         if (keyToHighlight != null) {
             val adapter = listView.adapter as? PreferenceGroupAdapter

--- a/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/MainSettingsFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/MainSettingsFragment.kt
@@ -8,6 +8,7 @@ import android.content.SharedPreferences
 import android.os.Build
 import android.os.Bundle
 import android.util.LayoutDirection
+import android.util.Log
 import android.view.Gravity
 import android.view.View
 import android.widget.TextView
@@ -16,6 +17,8 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import androidx.core.text.layoutDirection
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -65,6 +68,24 @@ class MainSettingsFragment : PreferenceFragmentCompat() {
     private lateinit var editor: SharedPreferences.Editor
 
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        ViewCompat.setOnApplyWindowInsetsListener(listView) { v, insets ->
+            val systemBars = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars()
+            )
+
+            v.setPadding(
+                v.paddingLeft,
+                v.paddingTop,
+                v.paddingRight,
+                v.paddingBottom + systemBars.bottom
+            )
+
+            insets
+        }
+    }
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.root_preferences, rootKey)
         val navController = findNavController()

--- a/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/SettingsActivity.kt
@@ -6,6 +6,8 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import androidx.activity.addCallback
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.Lifecycle
@@ -80,6 +82,21 @@ class SettingsActivity : BaseActivity(), SettingHost {
         binding = ActivitySettingsBinding.inflate(layoutInflater)
         settingViewModel = ViewModelProvider(this)[SettingsViewModel::class.java]
         setContentView(binding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.appBar) { v, insets ->
+            val topInset = insets.getInsets(
+                WindowInsetsCompat.Type.statusBars()
+            ).top
+
+            v.setPadding(
+                v.paddingLeft,
+                topInset,
+                v.paddingRight,
+                v.paddingBottom
+            )
+
+            insets
+        }
 
         val navHostFragment =
             supportFragmentManager.findFragmentById(R.id.frame_layout) as NavHostFragment

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -5,7 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
+    android:fitsSystemWindows="false"
     tools:context=".ui.more.settings.SettingsActivity">
 
     <com.google.android.material.search.SearchView


### PR DESCRIPTION
Fixes #1244

## Summary

Fixes an issue where the last settings items could be partially obscured and difficult to access on Android 16 devices, including the Source Code preference reported on Pixel 9 Pro devices.

### Changes

* Updated settings screen window inset handling.
* Fixed accessibility of the last preference items across settings screens.
* Tested on Android 16.
