### PR TITLE
Fix Generate PO Tokens screen scrolling

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="21" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
 </project>

--- a/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/BaseSettingsFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/BaseSettingsFragment.kt
@@ -81,6 +81,7 @@ abstract class BaseSettingsFragment : PreferenceFragmentCompat(), SettingHost {
                 WindowInsetsCompat.Type.systemBars()
             )
 
+
             v.setPadding(
                 v.paddingLeft,
                 v.paddingTop,

--- a/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/BaseSettingsFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/BaseSettingsFragment.kt
@@ -3,7 +3,10 @@ package com.deniscerri.ytdl.ui.more.settings
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import android.os.Bundle
+import android.util.Log
 import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
@@ -72,6 +75,22 @@ abstract class BaseSettingsFragment : PreferenceFragmentCompat(), SettingHost {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        ViewCompat.setOnApplyWindowInsetsListener(listView) { v, insets ->
+            val systemBars = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars()
+            )
+
+            v.setPadding(
+                v.paddingLeft,
+                v.paddingTop,
+                v.paddingRight,
+                v.paddingBottom + systemBars.bottom
+            )
+
+            insets
+        }
+
         val keyToHighlight = arguments?.getString("highlight_key")
         if (keyToHighlight != null) {
             val adapter = listView.adapter as? PreferenceGroupAdapter

--- a/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/MainSettingsFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/MainSettingsFragment.kt
@@ -8,6 +8,7 @@ import android.content.SharedPreferences
 import android.os.Build
 import android.os.Bundle
 import android.util.LayoutDirection
+import android.util.Log
 import android.view.Gravity
 import android.view.View
 import android.widget.TextView
@@ -16,6 +17,8 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import androidx.core.text.layoutDirection
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -65,6 +68,24 @@ class MainSettingsFragment : PreferenceFragmentCompat() {
     private lateinit var editor: SharedPreferences.Editor
 
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        ViewCompat.setOnApplyWindowInsetsListener(listView) { v, insets ->
+            val systemBars = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars()
+            )
+
+            v.setPadding(
+                v.paddingLeft,
+                v.paddingTop,
+                v.paddingRight,
+                v.paddingBottom + systemBars.bottom
+            )
+
+            insets
+        }
+    }
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.root_preferences, rootKey)
         val navController = findNavController()

--- a/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/SettingsActivity.kt
@@ -6,6 +6,8 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import androidx.activity.addCallback
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.Lifecycle
@@ -80,6 +82,21 @@ class SettingsActivity : BaseActivity(), SettingHost {
         binding = ActivitySettingsBinding.inflate(layoutInflater)
         settingViewModel = ViewModelProvider(this)[SettingsViewModel::class.java]
         setContentView(binding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.appBar) { v, insets ->
+            val topInset = insets.getInsets(
+                WindowInsetsCompat.Type.statusBars()
+            ).top
+
+            v.setPadding(
+                v.paddingLeft,
+                topInset,
+                v.paddingRight,
+                v.paddingBottom
+            )
+
+            insets
+        }
 
         val navHostFragment =
             supportFragmentManager.findFragmentById(R.id.frame_layout) as NavHostFragment

--- a/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/advanced/generateyoutubepotokens/GenerateYoutubePoTokensFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/advanced/generateyoutubepotokens/GenerateYoutubePoTokensFragment.kt
@@ -39,10 +39,10 @@ import kotlinx.coroutines.launch
 class GenerateYoutubePoTokensFragment : Fragment() {
     private lateinit var settingsActivity: SettingsActivity
     private lateinit var preferences: SharedPreferences
-    private lateinit var configuration : MutableList<YoutubeGeneratePoTokenItem>
-    private lateinit var workManager : WorkManager
+    private lateinit var configuration: MutableList<YoutubeGeneratePoTokenItem>
+    private lateinit var workManager: WorkManager
 
-    private lateinit var webPoTokenResultLauncher : ActivityResultLauncher<Intent>
+    private lateinit var webPoTokenResultLauncher: ActivityResultLauncher<Intent>
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -57,6 +57,7 @@ class GenerateYoutubePoTokensFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+
         super.onViewCreated(view, savedInstanceState)
         configuration = kotlin.runCatching {
             Gson().fromJson(
@@ -82,7 +83,8 @@ class GenerateYoutubePoTokensFragment : Fragment() {
         val playerClientDiv = requireView().findViewById<View>(R.id.playerclient_div)
         val playerClientText = requireView().findViewById<TextView>(R.id.content_playerclient)
 
-        val regenerate = requireView().findViewById<MaterialButton>(R.id.regenerate_webview_potokens)
+        val regenerate =
+            requireView().findViewById<MaterialButton>(R.id.regenerate_webview_potokens)
         val useVisitorData = requireView().findViewById<MaterialSwitch>(R.id.use_visitor_data)
 
         switch.isChecked = conf.enabled
@@ -130,7 +132,10 @@ class GenerateYoutubePoTokensFragment : Fragment() {
                         conf.clients.clear()
                         conf.clients.addAll(newValues)
                         configuration.add(conf)
-                        preferences.edit().putString("youtube_generated_po_tokens", Gson().toJson(configuration).toString()).apply()
+                        preferences.edit().putString(
+                            "youtube_generated_po_tokens",
+                            Gson().toJson(configuration).toString()
+                        ).apply()
                         setValues(conf)
                     }
                 }
@@ -142,8 +147,10 @@ class GenerateYoutubePoTokensFragment : Fragment() {
             ActivityResultContracts.StartActivityForResult()
         ) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
-                val streamingDataPoTokenResult = result.data!!.getStringExtra("streaming_potoken") ?: ""
-                val playerRequestPoTokenResult = result.data!!.getStringExtra("player_potoken") ?: ""
+                val streamingDataPoTokenResult =
+                    result.data!!.getStringExtra("streaming_potoken") ?: ""
+                val playerRequestPoTokenResult =
+                    result.data!!.getStringExtra("player_potoken") ?: ""
                 val subsRequestPoTokenResult = result.data!!.getStringExtra("subs_potoken") ?: ""
                 val visitorDataResult = result.data!!.getStringExtra("visitor_data") ?: ""
 
@@ -157,7 +164,10 @@ class GenerateYoutubePoTokensFragment : Fragment() {
 
                 configuration.add(conf)
                 setValues(conf)
-                preferences.edit().putString("youtube_generated_po_tokens", Gson().toJson(configuration).toString()).apply()
+                preferences.edit().putString(
+                    "youtube_generated_po_tokens",
+                    Gson().toJson(configuration).toString()
+                ).apply()
             }
         }
 
@@ -170,7 +180,9 @@ class GenerateYoutubePoTokensFragment : Fragment() {
             conf.enabled = switch.isChecked
             useVisitorData.isEnabled = switch.isChecked
             configuration.add(conf)
-            preferences.edit().putString("youtube_generated_po_tokens", Gson().toJson(configuration).toString()).apply()
+            preferences.edit()
+                .putString("youtube_generated_po_tokens", Gson().toJson(configuration).toString())
+                .apply()
             if (conf.poTokens.isEmpty()) {
                 regenerate.performClick()
             }
@@ -183,13 +195,16 @@ class GenerateYoutubePoTokensFragment : Fragment() {
                 configuration.remove(conf)
                 conf.useVisitorData = b
                 configuration.add(conf)
-                preferences.edit().putString("youtube_generated_po_tokens", Gson().toJson(configuration).toString()).apply()
+                preferences.edit().putString(
+                    "youtube_generated_po_tokens",
+                    Gson().toJson(configuration).toString()
+                ).apply()
             }
         }
 
     }
 
-    private fun showBottomSheet(){
+    private fun showBottomSheet() {
         lifecycleScope.launch {
             val dialog = MaterialAlertDialogBuilder(requireContext())
             dialog.setTitle(getString(R.string.generate_potokens))
@@ -216,13 +231,19 @@ class GenerateYoutubePoTokensFragment : Fragment() {
 
                     val intent = Intent(requireContext(), PoTokenWebViewLoginActivity::class.java)
                     intent.putExtra("url", "https://www.youtube.com")
-                    intent.putExtra("redirect_url", "https://www.youtube.com/watch?v=${editText.text.toString().getIDFromYoutubeURL()}")
+                    intent.putExtra(
+                        "redirect_url",
+                        "https://www.youtube.com/watch?v=${
+                            editText.text.toString().getIDFromYoutubeURL()
+                        }"
+                    )
                     intent.putExtra("no_auth", true)
                     webPoTokenResultLauncher.launch(intent)
                 }
 
 
-                val imm = requireActivity().getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+                val imm =
+                    requireActivity().getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
                 editText.postDelayed({
                     editText.requestFocus()
                     imm.showSoftInput(editText, 0)

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -5,7 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
+    android:fitsSystemWindows="false"
     tools:context=".ui.more.settings.SettingsActivity">
 
     <com.google.android.material.search.SearchView

--- a/app/src/main/res/layout/fragment_generate_youtube_po_token.xml
+++ b/app/src/main/res/layout/fragment_generate_youtube_po_token.xml
@@ -7,13 +7,17 @@
     tools:context="com.deniscerri.ytdl.ui.more.terminal.TerminalActivity">
 
     <ScrollView
+        android:id="@+id/scroll_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent">
 
         <LinearLayout
+            android:id="@+id/main_content"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:paddingBottom="120dp">
+
 
             <com.google.android.material.materialswitch.MaterialSwitch
                 android:id="@+id/web_client_switch"


### PR DESCRIPTION
Fixes #<1246>

When using larger system font sizes, the Generate PO Tokens screen does not allow scrolling far enough to access all controls at the bottom of the page.

This change adds additional bottom spacing so all controls remain reachable.