### PR TITLE
feat(music): music mode — tag audio downloads from online music catalogues

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -216,6 +216,7 @@ dependencies {
 
     implementation 'com.google.code.gson:gson:2.13.2'
     implementation "com.squareup.okhttp3:okhttp:5.3.2"
+    implementation "net.jthink:jaudiotagger:3.0.1"
 
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0'
     implementation 'it.xabaras.android:recyclerview-swipedecorator:1.4'

--- a/app/src/main/java/com/deniscerri/ytdl/database/models/AudioPreferences.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/database/models/AudioPreferences.kt
@@ -9,5 +9,7 @@ data class AudioPreferences(
     var cropThumb: Boolean? = null,
     var splitByChapters: Boolean = false,
     var sponsorBlockFilters: ArrayList<String> = arrayListOf(),
-    var bitrate: String = ""
+    var bitrate: String = "",
+    /** Set when the item is downloaded as music: tags written and file renamed after downloading. */
+    var musicMetadata: MusicMetadata? = null
 ) : Parcelable

--- a/app/src/main/java/com/deniscerri/ytdl/database/models/AudioPreferences.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/database/models/AudioPreferences.kt
@@ -10,6 +10,8 @@ data class AudioPreferences(
     var splitByChapters: Boolean = false,
     var sponsorBlockFilters: ArrayList<String> = arrayListOf(),
     var bitrate: String = "",
-    /** Set when the item is downloaded as music: tags written and file renamed after downloading. */
+    /** User intent: download this item as music. Remembered for the next download. */
+    var musicMode: Boolean = false,
+    /** The song resolved for this item: tags written and file renamed after downloading. */
     var musicMetadata: MusicMetadata? = null
 ) : Parcelable

--- a/app/src/main/java/com/deniscerri/ytdl/database/models/DownloadItem.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/database/models/DownloadItem.kt
@@ -28,8 +28,8 @@ data class DownloadItem(
     var website: String,
     val downloadSize: String,
     var playlistTitle: String,
-    val audioPreferences : AudioPreferences,
-    val videoPreferences: VideoPreferences,
+    var audioPreferences : AudioPreferences,
+    var videoPreferences: VideoPreferences,
     @ColumnInfo(defaultValue = "")
     var extraCommands: String,
     var customFileNameTemplate: String,

--- a/app/src/main/java/com/deniscerri/ytdl/database/models/MusicMetadata.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/database/models/MusicMetadata.kt
@@ -1,0 +1,28 @@
+package com.deniscerri.ytdl.database.models
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Music tags resolved for an audio download. Attached to [AudioPreferences] so the
+ * download worker can write them to the finished file and rename it accordingly.
+ */
+@Parcelize
+data class MusicMetadata(
+    var title: String = "",
+    var artist: String = "",
+    var album: String = "",
+    var year: String = "",
+    var genre: String = "",
+    var coverUrl: String = ""
+) : Parcelable {
+
+    val isUsable: Boolean
+        get() = title.isNotBlank() && artist.isNotBlank()
+
+    /** "Artist - Title", the display + filename form. */
+    fun displayName(): String = listOf(artist, title).filter { it.isNotBlank() }.joinToString(" - ")
+
+    /** "Album • Year", used as the card subtitle. */
+    fun details(): String = listOf(album, year).filter { it.isNotBlank() }.joinToString(" • ")
+}

--- a/app/src/main/java/com/deniscerri/ytdl/database/models/MusicMetadata.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/database/models/MusicMetadata.kt
@@ -4,8 +4,24 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 /**
+ * Where a [MusicMetadata] was resolved from, so the tags its catalogue only exposes on a
+ * detail endpoint can be fetched later, for the single result the user keeps.
+ */
+@Parcelize
+data class MusicSource(
+    val provider: String = "",
+    val trackId: String = "",
+    val albumId: String = ""
+) : Parcelable
+
+/**
  * Music tags resolved for an audio download. Attached to [AudioPreferences] so the
  * download worker can write them to the finished file and rename it accordingly.
+ *
+ * The first four fields identify the song and are always on screen, the ones after them are
+ * the extended tags the card keeps folded away until asked. Every field is optional beyond
+ * the title and the artist: catalogues differ in what they know, and a blank tag is simply
+ * one that never gets written.
  */
 @Parcelize
 data class MusicMetadata(
@@ -13,8 +29,15 @@ data class MusicMetadata(
     var artist: String = "",
     var album: String = "",
     var year: String = "",
+    var albumArtist: String = "",
     var genre: String = "",
-    var coverUrl: String = ""
+    var label: String = "",
+    var trackNumber: String = "",
+    var trackTotal: String = "",
+    var discNumber: String = "",
+    var isrc: String = "",
+    var coverUrl: String = "",
+    var source: MusicSource? = null
 ) : Parcelable {
 
     val isUsable: Boolean

--- a/app/src/main/java/com/deniscerri/ytdl/database/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/database/viewmodel/DownloadViewModel.kt
@@ -43,6 +43,7 @@ import com.deniscerri.ytdl.util.Extensions.needsDataUpdating
 import com.deniscerri.ytdl.util.Extensions.toListString
 import com.deniscerri.ytdl.util.FileUtil
 import com.deniscerri.ytdl.util.FormatUtil
+import com.deniscerri.ytdl.util.LastUsedDownloadSettings
 import com.deniscerri.ytdl.util.NotificationUtil
 import com.deniscerri.ytdl.util.extractors.ytdlp.YTDLPUtil
 import com.deniscerri.ytdl.util.AlarmScheduler
@@ -249,13 +250,19 @@ class DownloadViewModel(private val application: Application) : AndroidViewModel
                 if (urlsForAudioType.any { url.contains(it) }){
                     DownloadType.audio
                 }else{
-                    DownloadType.video
+                    //no site hint: open on the tab the user last downloaded from
+                    lastUsedDownloadType() ?: DownloadType.video
                 }
             }
 
             else -> type
         }
     }
+
+    private fun lastUsedDownloadType() : DownloadType? = runCatching {
+        DownloadType.valueOf(sharedPreferences.getString("last_used_download_type", "")!!)
+            .takeIf { it != DownloadType.auto }
+    }.getOrNull()
 
     fun createDownloadItemFromResult(result: ResultItem?, url: String = "", givenType: DownloadType) : DownloadItem {
         val resultItem = result ?: createEmptyResultItem(url)
@@ -355,7 +362,10 @@ class DownloadViewModel(private val application: Application) : AndroidViewModel
             playlistIndex = resultItem.playlistIndex,
             incognito = sharedPreferences.getBoolean("incognito", false),
             availableSubtitles = resultItem.availableSubtitles
-        )
+        ).also {
+            //the settings above are the app defaults, the last used download overrides them
+            LastUsedDownloadSettings.apply(sharedPreferences, it)
+        }
     }
 
     fun createResultItemFromDownload(downloadItem: DownloadItem) : ResultItem {

--- a/app/src/main/java/com/deniscerri/ytdl/database/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/database/viewmodel/DownloadViewModel.kt
@@ -236,12 +236,12 @@ class DownloadViewModel(private val application: Application) : AndroidViewModel
         var type = t
 
         if (type == null){
-            val preferredDownloadType = sharedPreferences.getString("preferred_download_type", DownloadType.auto.toString())
+            val preferredDownloadType = DownloadType.valueOf(
+                sharedPreferences.getString("preferred_download_type", DownloadType.auto.toString())!!)
             type = if (sharedPreferences.getBoolean("remember_download_type", false)){
-                DownloadType.valueOf(sharedPreferences.getString("last_used_download_type",
-                    preferredDownloadType)!!)
+                LastUsedDownloadSettings.lastType(sharedPreferences) ?: preferredDownloadType
             }else{
-                DownloadType.valueOf(preferredDownloadType!!)
+                preferredDownloadType
             }
         }
 
@@ -251,18 +251,13 @@ class DownloadViewModel(private val application: Application) : AndroidViewModel
                     DownloadType.audio
                 }else{
                     //no site hint: open on the tab the user last downloaded from
-                    lastUsedDownloadType() ?: DownloadType.video
+                    LastUsedDownloadSettings.lastType(sharedPreferences) ?: DownloadType.video
                 }
             }
 
             else -> type
         }
     }
-
-    private fun lastUsedDownloadType() : DownloadType? = runCatching {
-        DownloadType.valueOf(sharedPreferences.getString("last_used_download_type", "")!!)
-            .takeIf { it != DownloadType.auto }
-    }.getOrNull()
 
     fun createDownloadItemFromResult(result: ResultItem?, url: String = "", givenType: DownloadType) : DownloadItem {
         val resultItem = result ?: createEmptyResultItem(url)

--- a/app/src/main/java/com/deniscerri/ytdl/database/viewmodel/MusicViewModel.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/database/viewmodel/MusicViewModel.kt
@@ -61,10 +61,10 @@ class MusicViewModel : ViewModel() {
         launchSearch { MusicMetadataUtil.searchFromVideo(title, uploader) }
     }
 
-    /** Manual lookup with a user supplied artist and song name. */
-    fun search(artist: String, song: String) {
+    /** Manual lookup with a user supplied artist and song name, optionally aimed at one catalogue. */
+    fun search(artist: String, song: String, providerId: String?) {
         pin()
-        launchSearch { MusicMetadataUtil.search(artist, song) }
+        launchSearch { MusicMetadataUtil.search(artist, song, providerId) }
     }
 
     /** Shows another of the matches, completing its extended tags on the way in. */

--- a/app/src/main/java/com/deniscerri/ytdl/database/viewmodel/MusicViewModel.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/database/viewmodel/MusicViewModel.kt
@@ -1,0 +1,57 @@
+package com.deniscerri.ytdl.database.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.deniscerri.ytdl.database.models.MusicMetadata
+import com.deniscerri.ytdl.util.extractors.music.MusicMetadataUtil
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Owns the music lookup for a single download card. The picked/edited result itself lives in
+ * the download item, this only drives the search lifecycle so it survives configuration changes.
+ */
+class MusicViewModel : ViewModel() {
+
+    sealed class SearchState {
+        data object Idle : SearchState()
+        data object Loading : SearchState()
+        data class Found(val matches: List<MusicMetadata>) : SearchState()
+        data object NotFound : SearchState()
+    }
+
+    private val _state = MutableStateFlow<SearchState>(SearchState.Idle)
+    val state = _state.asStateFlow()
+
+    private var searchJob: Job? = null
+
+    /** Automatic lookup from the fetched video info. */
+    fun searchFromVideo(videoTitle: String, uploader: String) =
+        launchSearch { MusicMetadataUtil.searchFromVideo(videoTitle, uploader) }
+
+    /** Manual lookup with a user supplied artist and song name. */
+    fun search(artist: String, song: String) =
+        launchSearch { MusicMetadataUtil.search(artist, song) }
+
+    /** Marks the state as resolved without a new request (restored or user edited metadata). */
+    fun setMatches(matches: List<MusicMetadata>) {
+        searchJob?.cancel()
+        _state.value = if (matches.isEmpty()) SearchState.NotFound else SearchState.Found(matches)
+    }
+
+    fun reset() {
+        searchJob?.cancel()
+        _state.value = SearchState.Idle
+    }
+
+    private fun launchSearch(query: suspend () -> List<MusicMetadata>) {
+        searchJob?.cancel()
+        _state.value = SearchState.Loading
+        searchJob = viewModelScope.launch {
+            val matches = query()
+            _state.value = if (matches.isEmpty()) SearchState.NotFound else SearchState.Found(matches)
+        }
+    }
+}

--- a/app/src/main/java/com/deniscerri/ytdl/database/viewmodel/MusicViewModel.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/database/viewmodel/MusicViewModel.kt
@@ -10,15 +10,26 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 /**
- * Owns the music lookup for a single download card. The picked/edited result itself lives in
- * the download item, this only drives the search lifecycle so it survives configuration changes.
+ * Owns the music lookup for a single download card. The picked result itself lives on the
+ * download item, this only drives the search lifecycle.
+ *
+ * The card is shown before the video info is fetched, so the lookup follows the video data:
+ * it waits while the title is still unknown and re-runs once the real title arrives, unless
+ * the user already made the result their own.
+ *
+ * A search only returns what the catalogue could answer in one request. The extended tags are
+ * completed afterwards, for the shown match alone, and the state is re-emitted when they land
+ * so the card fills itself in without ever blocking the result the user is already reading.
  */
 class MusicViewModel : ViewModel() {
 
     sealed class SearchState {
         data object Idle : SearchState()
+        /** The video info is not fetched yet, so there is nothing to search for. */
+        data object Waiting : SearchState()
         data object Loading : SearchState()
-        data class Found(val matches: List<MusicMetadata>) : SearchState()
+        /** [matches] ranked by the catalogue, [selected] is the one the card shows. */
+        data class Found(val matches: List<MusicMetadata>, val selected: Int = 0) : SearchState()
         data object NotFound : SearchState()
     }
 
@@ -26,32 +37,95 @@ class MusicViewModel : ViewModel() {
     val state = _state.asStateFlow()
 
     private var searchJob: Job? = null
+    private var detailsJob: Job? = null
+    private var lastQuery: String? = null
 
-    /** Automatic lookup from the fetched video info. */
-    fun searchFromVideo(videoTitle: String, uploader: String) =
-        launchSearch { MusicMetadataUtil.searchFromVideo(videoTitle, uploader) }
+    /** Matches already completed, so picking one back costs nothing. */
+    private val detailed = mutableSetOf<Int>()
+
+    /** Set once the user searches, picks or edits a result, so syncs stop overwriting it. */
+    private var pinned = false
+
+    /** Keeps the lookup in sync with the video info, whenever it becomes available or changes. */
+    fun syncWithVideo(title: String, uploader: String, url: String) {
+        if (pinned) return
+
+        if (title.isBlank() || title == url) {
+            _state.value = SearchState.Waiting
+            return
+        }
+
+        val query = "$title|$uploader"
+        if (query == lastQuery) return
+        lastQuery = query
+        launchSearch { MusicMetadataUtil.searchFromVideo(title, uploader) }
+    }
 
     /** Manual lookup with a user supplied artist and song name. */
-    fun search(artist: String, song: String) =
+    fun search(artist: String, song: String) {
+        pin()
         launchSearch { MusicMetadataUtil.search(artist, song) }
+    }
 
-    /** Marks the state as resolved without a new request (restored or user edited metadata). */
-    fun setMatches(matches: List<MusicMetadata>) {
-        searchJob?.cancel()
-        _state.value = if (matches.isEmpty()) SearchState.NotFound else SearchState.Found(matches)
+    /** Shows another of the matches, completing its extended tags on the way in. */
+    fun select(index: Int) {
+        val found = _state.value as? SearchState.Found ?: return
+        if (index == found.selected || index !in found.matches.indices) return
+        pin()
+        _state.value = found.copy(selected = index)
+        loadDetails(index)
+    }
+
+    /**
+     * Protects the current result from being replaced. Also drops a pending completion: once
+     * the user is typing, their fields are the truth and nothing may write over them.
+     */
+    fun pin() {
+        pinned = true
+        detailsJob?.cancel()
     }
 
     fun reset() {
         searchJob?.cancel()
+        detailsJob?.cancel()
+        detailed.clear()
+        lastQuery = null
+        pinned = false
         _state.value = SearchState.Idle
     }
 
     private fun launchSearch(query: suspend () -> List<MusicMetadata>) {
         searchJob?.cancel()
+        detailsJob?.cancel()
+        detailed.clear()
         _state.value = SearchState.Loading
         searchJob = viewModelScope.launch {
             val matches = query()
-            _state.value = if (matches.isEmpty()) SearchState.NotFound else SearchState.Found(matches)
+            if (matches.isEmpty()) {
+                _state.value = SearchState.NotFound
+                return@launch
+            }
+            _state.value = SearchState.Found(matches)
+            loadDetails(0)
+        }
+    }
+
+    /** Replaces one match with its completed form, leaving the rest of the result list alone. */
+    private fun loadDetails(index: Int) {
+        if (index in detailed) return
+        detailsJob?.cancel()
+        detailsJob = viewModelScope.launch {
+            val found = _state.value as? SearchState.Found ?: return@launch
+            val completed = MusicMetadataUtil.details(found.matches[index])
+
+            //a search that landed meanwhile owns a different list, this result is stale
+            val current = _state.value as? SearchState.Found ?: return@launch
+            if (current.matches !== found.matches) return@launch
+
+            detailed += index
+            _state.value = current.copy(
+                matches = current.matches.toMutableList().also { it[index] = completed }
+            )
         }
     }
 }

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/ConfigureDownloadBottomSheetDialog.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/ConfigureDownloadBottomSheetDialog.kt
@@ -13,7 +13,6 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
 import android.widget.Toast
-import androidx.core.content.edit
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
@@ -181,10 +180,6 @@ class ConfigureDownloadBottomSheetDialog(private val currentDownloadItem: Downlo
             override fun onPageSelected(position: Int) {
                 tabLayout.selectTab(tabLayout.getTabAt(position))
                 runCatching {
-                    sharedPreferences.edit(commit = true) {
-                        putString("last_used_download_type",
-                            listOf(DownloadType.audio, DownloadType.video, DownloadType.command)[position].toString())
-                    }
                     fragmentAdapter.updateWhenSwitching(viewPager2.currentItem)
                 }
             }

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
@@ -17,6 +17,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.content.edit
 import androidx.core.view.isVisible
 import androidx.core.view.setPadding
 import androidx.fragment.app.Fragment
@@ -27,9 +28,11 @@ import com.deniscerri.ytdl.R
 import com.deniscerri.ytdl.database.enums.DownloadType
 import com.deniscerri.ytdl.database.models.DownloadItem
 import com.deniscerri.ytdl.database.models.Format
+import com.deniscerri.ytdl.database.models.MusicMetadata
 import com.deniscerri.ytdl.database.models.ResultItem
 import com.deniscerri.ytdl.database.viewmodel.DownloadViewModel
 import com.deniscerri.ytdl.database.viewmodel.FormatViewModel
+import com.deniscerri.ytdl.database.viewmodel.MusicViewModel
 import com.deniscerri.ytdl.database.viewmodel.ResultViewModel
 import com.deniscerri.ytdl.database.viewmodel.YTDLPViewModel
 import com.deniscerri.ytdl.util.Extensions.applyFilenameTemplateForCuts
@@ -37,6 +40,7 @@ import com.deniscerri.ytdl.util.Extensions.createBadge
 import com.deniscerri.ytdl.util.FileUtil
 import com.deniscerri.ytdl.util.FormatUtil
 import com.deniscerri.ytdl.util.UiUtil
+import com.deniscerri.ytdl.util.extractors.music.MusicMetadataUtil
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.chip.Chip
 import com.google.android.material.snackbar.Snackbar
@@ -59,6 +63,8 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
     private lateinit var resultViewModel : ResultViewModel
     private lateinit var ytdlpViewModel : YTDLPViewModel
     private lateinit var formatViewModel : FormatViewModel
+    private lateinit var musicViewModel : MusicViewModel
+    private lateinit var musicCard : MusicMetadataCard
     private lateinit var saveDir : TextInputLayout
     private lateinit var freeSpace : TextView
     private lateinit var genericAudioFormats: MutableList<Format>
@@ -83,6 +89,7 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
         resultViewModel = ViewModelProvider(this)[ResultViewModel::class.java]
         ytdlpViewModel = ViewModelProvider(requireActivity())[YTDLPViewModel::class.java]
         formatViewModel = ViewModelProvider(requireActivity())[FormatViewModel::class.java]
+        musicViewModel = ViewModelProvider(this)[MusicViewModel::class.java]
         genericAudioFormats = FormatUtil(requireContext()).getGenericAudioFormats(requireContext().resources)
         preferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
         shownFields = preferences.getStringSet("modify_download_card", requireContext().resources.getStringArray(R.array.modify_download_card_values).toSet())!!.toList()
@@ -173,6 +180,8 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
                     author.endIconMode = END_ICON_NONE
                 }
 
+                if (::musicCard.isInitialized) toggleTitleFields(musicCard.isEnabled)
+                else setupMusicCard(view)
 
                 saveDir = view.findViewById(R.id.outputPath)
                 saveDir.editText!!.setText(
@@ -415,6 +424,75 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
                 }
             }
         }
+    }
+
+    /**
+     * Music mode: resolves the real song info for the fetched video and keeps it on the
+     * download item, so the worker can tag and name the finished file with it.
+     */
+    private fun setupMusicCard(view: View) {
+        val card = view.findViewById<View>(R.id.music_card)
+        if (nonSpecific) {
+            card.visibility = View.GONE
+            return
+        }
+
+        musicCard = MusicMetadataCard(
+            root = view,
+            onModeChanged = { enabled -> setMusicMode(enabled) },
+            onMetadataChanged = { metadata ->
+                downloadItem.audioPreferences.musicMetadata = metadata.takeIf { it.isUsable }
+            },
+            onSearchRequested = { artist, song ->
+                downloadItem.audioPreferences.musicMetadata = null
+                musicViewModel.search(artist, song)
+            }
+        )
+
+        lifecycleScope.launch {
+            musicViewModel.state.collectLatest { state ->
+                when (state) {
+                    is MusicViewModel.SearchState.Loading -> musicCard.showLoading()
+                    is MusicViewModel.SearchState.Found -> musicCard.showMetadata(
+                        downloadItem.audioPreferences.musicMetadata ?: state.matches.first(),
+                        state.matches
+                    )
+                    is MusicViewModel.SearchState.NotFound -> musicCard.showNotFound(parsedSongGuess())
+                    is MusicViewModel.SearchState.Idle -> {}
+                }
+            }
+        }
+
+        val saved = downloadItem.audioPreferences.musicMetadata
+        val enabled = saved != null || preferences.getBoolean("music_mode", false)
+        musicCard.setChecked(enabled)
+        toggleTitleFields(enabled)
+
+        if (enabled) {
+            if (saved != null) musicCard.showMetadata(saved)
+            else musicViewModel.searchFromVideo(downloadItem.title, downloadItem.author)
+        }
+    }
+
+    private fun setMusicMode(enabled: Boolean) {
+        preferences.edit { putBoolean("music_mode", enabled) }
+        toggleTitleFields(enabled)
+        downloadItem.audioPreferences.musicMetadata = null
+
+        if (enabled) musicViewModel.searchFromVideo(downloadItem.title, downloadItem.author)
+        else musicViewModel.reset()
+    }
+
+    /** The song fields replace the video title/author fields while music mode is on. */
+    private fun toggleTitleFields(musicMode: Boolean) {
+        title.visibility = if (!musicMode && shownFields.contains("title")) View.VISIBLE else View.GONE
+        author.visibility = if (!musicMode && shownFields.contains("author")) View.VISIBLE else View.GONE
+    }
+
+    /** Best effort artist/song split of the video title, shown when no API match exists. */
+    private fun parsedSongGuess(): MusicMetadata {
+        val (artist, song) = MusicMetadataUtil.buildSearchQueries(downloadItem.title, downloadItem.author).first()
+        return MusicMetadata(title = song, artist = artist)
     }
 
     @SuppressLint("RestrictedApi")

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
@@ -17,7 +17,6 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.content.edit
 import androidx.core.view.isVisible
 import androidx.core.view.setPadding
 import androidx.fragment.app.Fragment
@@ -39,6 +38,7 @@ import com.deniscerri.ytdl.util.Extensions.applyFilenameTemplateForCuts
 import com.deniscerri.ytdl.util.Extensions.createBadge
 import com.deniscerri.ytdl.util.FileUtil
 import com.deniscerri.ytdl.util.FormatUtil
+import com.deniscerri.ytdl.util.LastUsedDownloadSettings
 import com.deniscerri.ytdl.util.UiUtil
 import com.deniscerri.ytdl.util.extractors.music.MusicMetadataUtil
 import com.google.android.material.card.MaterialCardView
@@ -264,7 +264,8 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
                         }
                         formats = allFormats.filter { !genericAudioFormats.contains(it) }.toMutableList()
                         formats.removeAll(genericAudioFormats)
-                        val preferredFormat = downloadViewModel.getFormat(formats, DownloadType.audio)
+                        val preferredFormat = LastUsedDownloadSettings.rememberedFormat(preferences, downloadItem, formats)
+                            ?: downloadViewModel.getFormat(formats, DownloadType.audio)
                         downloadItem.format = preferredFormat
                         downloadItem.allFormats = formats
                         val filesize = UiUtil.populateFormatCard(requireContext(), formatCard, preferredFormat, null, showSize = downloadItem.downloadSections.isEmpty())
@@ -293,7 +294,8 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
                     )
                 )
 
-                if (currentDownloadItem == null || !containers.contains(downloadItem.container.ifEmpty { getString(R.string.defaultValue) })){
+                //the item already carries the app default or the last used container, only fix invalid ones
+                if (!containers.contains(downloadItem.container.ifEmpty { getString(R.string.defaultValue) })){
                     downloadItem.container = if (containerPreference == getString(R.string.defaultValue)) "" else containerPreference!!
                 }
                 containerAutoCompleteTextView.setText(downloadItem.container.ifEmpty { getString(R.string.defaultValue) }, false)
@@ -464,7 +466,7 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
         }
 
         val saved = downloadItem.audioPreferences.musicMetadata
-        val enabled = saved != null || preferences.getBoolean("music_mode", false)
+        val enabled = saved != null || downloadItem.audioPreferences.musicMode
         musicCard.setChecked(enabled)
         toggleTitleFields(enabled)
 
@@ -475,7 +477,7 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
     }
 
     private fun setMusicMode(enabled: Boolean) {
-        preferences.edit { putBoolean("music_mode", enabled) }
+        downloadItem.audioPreferences.musicMode = enabled
         toggleTitleFields(enabled)
         downloadItem.audioPreferences.musicMetadata = null
 

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
@@ -180,8 +180,11 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
                     author.endIconMode = END_ICON_NONE
                 }
 
-                if (::musicCard.isInitialized) toggleTitleFields(musicCard.isEnabled)
-                else setupMusicCard(view)
+                if (::musicCard.isInitialized) {
+                    toggleTitleFields(musicCard.isEnabled)
+                    //the video info may have just landed, the lookup follows it
+                    syncMusicLookup()
+                } else setupMusicCard(view)
 
                 saveDir = view.findViewById(R.id.outputPath)
                 saveDir.editText!!.setText(
@@ -442,9 +445,12 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
         musicCard = MusicMetadataCard(
             root = view,
             onModeChanged = { enabled -> setMusicMode(enabled) },
-            onMetadataChanged = { metadata ->
+            onMetadataChanged = { metadata, byUser ->
                 downloadItem.audioPreferences.musicMetadata = metadata.takeIf { it.isUsable }
+                //an edited or handpicked result is the users own, no later sync may replace it
+                if (byUser) musicViewModel.pin()
             },
+            onMatchSelected = { index -> musicViewModel.select(index) },
             onSearchRequested = { artist, song ->
                 downloadItem.audioPreferences.musicMetadata = null
                 musicViewModel.search(artist, song)
@@ -454,11 +460,9 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
         lifecycleScope.launch {
             musicViewModel.state.collectLatest { state ->
                 when (state) {
+                    is MusicViewModel.SearchState.Waiting -> musicCard.showWaiting()
                     is MusicViewModel.SearchState.Loading -> musicCard.showLoading()
-                    is MusicViewModel.SearchState.Found -> musicCard.showMetadata(
-                        downloadItem.audioPreferences.musicMetadata ?: state.matches.first(),
-                        state.matches
-                    )
+                    is MusicViewModel.SearchState.Found -> musicCard.showMetadata(state.matches, state.selected)
                     is MusicViewModel.SearchState.NotFound -> musicCard.showNotFound(parsedSongGuess())
                     is MusicViewModel.SearchState.Idle -> {}
                 }
@@ -470,19 +474,31 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
         musicCard.setChecked(enabled)
         toggleTitleFields(enabled)
 
-        if (enabled) {
-            if (saved != null) musicCard.showMetadata(saved)
-            else musicViewModel.searchFromVideo(downloadItem.title, downloadItem.author)
+        //a restored song was already settled, only a fresh card looks one up
+        if (saved != null) {
+            musicViewModel.pin()
+            musicCard.showMetadata(saved)
+        } else {
+            syncMusicLookup()
         }
     }
 
     private fun setMusicMode(enabled: Boolean) {
         downloadItem.audioPreferences.musicMode = enabled
-        toggleTitleFields(enabled)
         downloadItem.audioPreferences.musicMetadata = null
+        toggleTitleFields(enabled)
 
-        if (enabled) musicViewModel.searchFromVideo(downloadItem.title, downloadItem.author)
-        else musicViewModel.reset()
+        musicViewModel.reset()
+        if (enabled) syncMusicLookup()
+    }
+
+    /**
+     * Follows the video info, which is fetched after the card is built and can change again
+     * when the item is updated. Does nothing until there is a real title to look up.
+     */
+    private fun syncMusicLookup() {
+        if (!::musicCard.isInitialized || !musicCard.isEnabled) return
+        musicViewModel.syncWithVideo(downloadItem.title, downloadItem.author, downloadItem.url)
     }
 
     /** The song fields replace the video title/author fields while music mode is on. */

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
@@ -65,6 +65,7 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
     private lateinit var formatViewModel : FormatViewModel
     private lateinit var musicViewModel : MusicViewModel
     private lateinit var musicCard : MusicMetadataCard
+    private lateinit var coverDialog : MusicCoverDialog
     private lateinit var saveDir : TextInputLayout
     private lateinit var freeSpace : TextView
     private lateinit var genericAudioFormats: MutableList<Format>
@@ -451,10 +452,18 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
                 if (byUser) musicViewModel.pin()
             },
             onMatchSelected = { index -> musicViewModel.select(index) },
+            onCoverClicked = { cover -> coverDialog.show(cover) },
             onSearchRequested = { artist, song, providerId ->
                 downloadItem.audioPreferences.musicMetadata = null
                 musicViewModel.search(artist, song, providerId)
             }
+        )
+
+        coverDialog = MusicCoverDialog(
+            context = requireContext(),
+            scope = viewLifecycleOwner.lifecycleScope,
+            onPickRequested = { pickCover() },
+            onCoverConfirmed = { musicCard.setCover(it) }
         )
 
         lifecycleScope.launch {
@@ -542,6 +551,29 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
             disabledCutClicked = false
         }
         onViewCreated(requireView(),savedInstanceState = state)
+    }
+
+    /**
+     * The cover picker, opened on behalf of [coverDialog]. Registered here because this
+     * fragment is a dependable owner of an activity result, and launched the same way as the
+     * download folder picker below, which is the only such flow this screen already relies on.
+     */
+    private fun pickCover() {
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
+        intent.addCategory(Intent.CATEGORY_OPENABLE)
+        intent.type = "image/*"
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+
+        coverResultLauncher.launch(intent)
+    }
+
+    private var coverResultLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode != Activity.RESULT_OK) return@registerForActivityResult
+        //the card builds asynchronously, a result from before it was ready has nowhere to land
+        if (!::coverDialog.isInitialized) return@registerForActivityResult
+        result.data?.data?.let { coverDialog.preview(it) }
     }
 
     private var pathResultLauncher = registerForActivityResult(

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadAudioFragment.kt
@@ -451,9 +451,9 @@ class DownloadAudioFragment(private var resultItem: ResultItem? = null, private 
                 if (byUser) musicViewModel.pin()
             },
             onMatchSelected = { index -> musicViewModel.select(index) },
-            onSearchRequested = { artist, song ->
+            onSearchRequested = { artist, song, providerId ->
                 downloadItem.audioPreferences.musicMetadata = null
-                musicViewModel.search(artist, song)
+                musicViewModel.search(artist, song, providerId)
             }
         )
 

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadBottomSheetDialog.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadBottomSheetDialog.kt
@@ -19,7 +19,6 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.content.edit
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -240,12 +239,6 @@ class DownloadBottomSheetDialog : BottomSheetDialogFragment() {
             }
         }
 
-        sharedPreferences.edit(commit = true) {
-            putString("last_used_download_type",
-                type.toString())
-        }
-
-
         tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab?) {
                 if (tab!!.position == 2 && commandTemplateNr == 0){
@@ -289,10 +282,6 @@ class DownloadBottomSheetDialog : BottomSheetDialogFragment() {
             override fun onPageSelected(position: Int) {
                 tabLayout.selectTab(tabLayout.getTabAt(position))
                 runCatching {
-                    sharedPreferences.edit(commit = true) {
-                        putString("last_used_download_type",
-                            listOf(DownloadType.audio, DownloadType.video, DownloadType.command)[position].toString())
-                    }
                     fragmentAdapter.updateWhenSwitching(viewPager2.currentItem)
                 }
             }
@@ -320,7 +309,7 @@ class DownloadBottomSheetDialog : BottomSheetDialogFragment() {
 
                 scheduleBtn.isEnabled = false
                 download.isEnabled = false
-                val item: DownloadItem = getDownloadItem()
+                val item: DownloadItem = commitDownloadItem()
                 item.status = DownloadRepository.Status.Scheduled.toString()
                 item.downloadStartTime = it.timeInMillis
                 if (item.videoPreferences.alsoDownloadAsAudio){
@@ -370,7 +359,7 @@ class DownloadBottomSheetDialog : BottomSheetDialogFragment() {
                 resultViewModel.cancelUpdateFormatsItemData()
                 scheduleBtn.isEnabled = false
                 download.isEnabled = false
-                val item: DownloadItem = getDownloadItem()
+                val item: DownloadItem = commitDownloadItem()
                 if (item.videoPreferences.alsoDownloadAsAudio){
                     val itemsToQueue = mutableListOf<DownloadItem>()
                     itemsToQueue.add(item)
@@ -402,7 +391,7 @@ class DownloadBottomSheetDialog : BottomSheetDialogFragment() {
             dd.setNegativeButton(getString(R.string.cancel)) { dialogInterface: DialogInterface, _: Int -> dialogInterface.cancel() }
             dd.setPositiveButton(getString(R.string.ok)) { _: DialogInterface?, _: Int ->
                 lifecycleScope.launch(Dispatchers.IO){
-                    downloadViewModel.putToSaved(getDownloadItem())
+                    downloadViewModel.putToSaved(commitDownloadItem())
                     dismiss()
                 }
             }
@@ -680,8 +669,15 @@ class DownloadBottomSheetDialog : BottomSheetDialogFragment() {
     }
 
     private fun getDownloadItem(selectedTabPosition: Int = tabLayout.selectedTabPosition) : DownloadItem {
-        return fragmentAdapter.getDownloadItem(selectedTabPosition).also {
-            //whatever the user configured here becomes the default of the next download
+        return fragmentAdapter.getDownloadItem(selectedTabPosition)
+    }
+
+    /**
+     * The item the user is committing to: whatever it was configured with becomes the starting
+     * point of the next download of that type. Browsing the card must not go through here.
+     */
+    private fun commitDownloadItem(selectedTabPosition: Int = tabLayout.selectedTabPosition) : DownloadItem {
+        return getDownloadItem(selectedTabPosition).also {
             LastUsedDownloadSettings.save(sharedPreferences, it)
         }
     }

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadBottomSheetDialog.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadBottomSheetDialog.kt
@@ -43,6 +43,7 @@ import com.deniscerri.ytdl.database.viewmodel.ResultViewModel
 import com.deniscerri.ytdl.receiver.ShareActivity
 import com.deniscerri.ytdl.ui.BaseActivity
 import com.deniscerri.ytdl.ui.more.cookies.WebViewActivity
+import com.deniscerri.ytdl.util.LastUsedDownloadSettings
 import com.deniscerri.ytdl.util.UiUtil
 import com.facebook.shimmer.ShimmerFrameLayout
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -679,7 +680,10 @@ class DownloadBottomSheetDialog : BottomSheetDialogFragment() {
     }
 
     private fun getDownloadItem(selectedTabPosition: Int = tabLayout.selectedTabPosition) : DownloadItem {
-        return fragmentAdapter.getDownloadItem(selectedTabPosition)
+        return fragmentAdapter.getDownloadItem(selectedTabPosition).also {
+            //whatever the user configured here becomes the default of the next download
+            LastUsedDownloadSettings.save(sharedPreferences, it)
+        }
     }
 
     private fun getAlsoAudioDownloadItem(finished: (it: DownloadItem) -> Unit) {

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadVideoFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/DownloadVideoFragment.kt
@@ -37,6 +37,7 @@ import com.deniscerri.ytdl.util.Extensions.applyFilenameTemplateForCuts
 import com.deniscerri.ytdl.util.Extensions.createBadge
 import com.deniscerri.ytdl.util.FileUtil
 import com.deniscerri.ytdl.util.FormatUtil
+import com.deniscerri.ytdl.util.LastUsedDownloadSettings
 import com.deniscerri.ytdl.util.UiUtil
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.chip.Chip
@@ -289,7 +290,8 @@ class DownloadVideoFragment(private var resultItem: ResultItem? = null, private 
                             }
                         }
                         formats = allFormats.filter { !genericVideoFormats.contains(it) }.toMutableList()
-                        val preferredFormat = downloadViewModel.getFormat(formats, DownloadType.video)
+                        val preferredFormat = LastUsedDownloadSettings.rememberedFormat(preferences, downloadItem, formats)
+                            ?: downloadViewModel.getFormat(formats, DownloadType.video)
                         val preferredAudioFormats = downloadViewModel.getPreferredAudioFormats(formats)
                         downloadItem.format = preferredFormat
                         downloadItem.allFormats = formats
@@ -322,7 +324,8 @@ class DownloadVideoFragment(private var resultItem: ResultItem? = null, private 
                         containers
                     )
                 )
-                if (currentDownloadItem == null || !containers.contains(downloadItem.container.ifEmpty { getString(R.string.defaultValue) })){
+                //the item already carries the app default or the last used container, only fix invalid ones
+                if (!containers.contains(downloadItem.container.ifEmpty { getString(R.string.defaultValue) })){
                     downloadItem.container = if (containerPreference == getString(R.string.defaultValue)) "" else containerPreference!!
                 }
                 containerAutoCompleteTextView!!.setText(

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/MusicCoverDialog.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/MusicCoverDialog.kt
@@ -1,0 +1,95 @@
+package com.deniscerri.ytdl.ui.downloadcard
+
+import android.content.Context
+import android.net.Uri
+import android.view.LayoutInflater
+import com.deniscerri.ytdl.R
+import com.deniscerri.ytdl.util.MusicCoverUtil
+import com.facebook.shimmer.ShimmerFrameLayout
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.imageview.ShapeableImageView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+/**
+ * Shows the album cover at a size worth looking at, and lets the user replace it with a
+ * picture from the device.
+ *
+ * Picking only previews: the choice is not the users until they confirm it, so the cover on
+ * the card stays untouched while they look at the alternative and change their mind.
+ *
+ * Deliberately a plain dialog owned by the audio card rather than a fragment of its own. The
+ * card already owns the file picker and the card is what the result is for, so keeping both
+ * in one place removes the hand off between fragments entirely: nothing here has a lifecycle
+ * that can be stopped, capped or rebuilt while the picker is in front.
+ */
+class MusicCoverDialog(
+    private val context: Context,
+    private val scope: CoroutineScope,
+    private val onPickRequested: () -> Unit,
+    private val onCoverConfirmed: (cover: String) -> Unit
+) {
+    private val dialog = BottomSheetDialog(context)
+    private val view = LayoutInflater.from(context).inflate(R.layout.sheet_music_cover, null)
+
+    private val preview: ShapeableImageView = view.findViewById(R.id.cover_preview)
+    private val shimmer: ShimmerFrameLayout = view.findViewById(R.id.cover_shimmer)
+    private val confirm: MaterialButton = view.findViewById(R.id.cover_confirm)
+
+    /** The previewed image, still uncommitted until [confirm] is pressed. */
+    private var picked: Uri? = null
+
+    /** Renders the previewed cover, replaced whenever the user points at another one. */
+    private var renderJob: Job? = null
+
+    init {
+        dialog.setContentView(view)
+        view.findViewById<MaterialButton>(R.id.cover_choose).setOnClickListener { onPickRequested() }
+        confirm.setOnClickListener {
+            val uri = picked ?: return@setOnClickListener
+            MusicCoverUtil.store(context, uri)?.let(onCoverConfirmed)
+            dialog.dismiss()
+        }
+    }
+
+    /** Opens on [cover], the artwork the card is currently carrying. */
+    fun show(cover: String) {
+        picked = null
+        confirm.isEnabled = false
+        render(cover)
+        dialog.show()
+    }
+
+    /**
+     * Shows an image the card picked up from the device. Reopens the sheet when the picker
+     * closed it on the way, so a chosen image always lands somewhere the user can confirm it.
+     */
+    fun preview(uri: Uri) {
+        picked = uri
+        confirm.isEnabled = true
+        render(uri.toString())
+        if (!dialog.isShowing) dialog.show()
+    }
+
+    /**
+     * Decoding is off the main thread, so a slow source never holds the sheet open empty. The
+     * shimmer covers that gap, and covers it again whenever the user points at another image.
+     */
+    private fun render(cover: String) {
+        renderJob?.cancel()
+        shimmer.showShimmer(true)
+        renderJob = scope.launch {
+            val bitmap = MusicCoverUtil.preview(context, cover, PREVIEW_MAX_SIZE)
+            if (bitmap == null) preview.setImageResource(R.drawable.ic_music)
+            else preview.setImageBitmap(bitmap)
+            shimmer.hideShimmer()
+        }
+    }
+
+    companion object {
+        /** Longest edge the preview decodes to, comfortably above any screen it is shown on. */
+        private const val PREVIEW_MAX_SIZE = 1080
+    }
+}

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/MusicMetadataCard.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/MusicMetadataCard.kt
@@ -10,12 +10,14 @@ import android.widget.TextView
 import androidx.core.view.setPadding
 import com.deniscerri.ytdl.R
 import com.deniscerri.ytdl.database.models.MusicMetadata
+import com.deniscerri.ytdl.util.extractors.music.MusicMetadataUtil
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.chip.Chip
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.imageview.ShapeableImageView
 import com.google.android.material.materialswitch.MaterialSwitch
 import com.google.android.material.progressindicator.CircularProgressIndicator
+import com.google.android.material.textfield.MaterialAutoCompleteTextView
 import com.google.android.material.textfield.TextInputLayout
 import com.squareup.picasso.Picasso
 
@@ -35,7 +37,7 @@ class MusicMetadataCard(
     private val onModeChanged: (enabled: Boolean) -> Unit,
     private val onMetadataChanged: (metadata: MusicMetadata, byUser: Boolean) -> Unit,
     private val onMatchSelected: (index: Int) -> Unit,
-    private val onSearchRequested: (artist: String, song: String) -> Unit
+    private val onSearchRequested: (artist: String, song: String, providerId: String?) -> Unit
 ) {
     private val context: Context = root.context
 
@@ -201,12 +203,27 @@ class MusicMetadataCard(
         artistInput.setText(current.artist)
         songInput.setText(current.title)
 
+        //the catalogues, preceded by the default of consulting them in order
+        val providerIds = listOf(null) + MusicMetadataUtil.catalogues.map { (id, _) -> id }
+        val providerInput = input(view, R.id.music_search_provider) as MaterialAutoCompleteTextView
+        providerInput.setSimpleItems(
+            (listOf(context.getString(R.string.all_sources)) + MusicMetadataUtil.catalogues.map { (_, name) -> name })
+                .toTypedArray()
+        )
+        var provider = 0
+        providerInput.setText(context.getString(R.string.all_sources), false)
+        providerInput.setOnItemClickListener { _, _, index, _ -> provider = index }
+
         MaterialAlertDialogBuilder(context)
             .setTitle(R.string.search_song)
             .setView(view)
             .setNegativeButton(R.string.cancel, null)
             .setPositiveButton(R.string.search) { _, _ ->
-                onSearchRequested(artistInput.text.toString().trim(), songInput.text.toString().trim())
+                onSearchRequested(
+                    artistInput.text.toString().trim(),
+                    songInput.text.toString().trim(),
+                    providerIds[provider]
+                )
             }
             .show()
     }

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/MusicMetadataCard.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/MusicMetadataCard.kt
@@ -10,16 +10,17 @@ import android.widget.TextView
 import androidx.core.view.setPadding
 import com.deniscerri.ytdl.R
 import com.deniscerri.ytdl.database.models.MusicMetadata
+import com.deniscerri.ytdl.util.MusicCoverUtil
 import com.deniscerri.ytdl.util.extractors.music.MusicMetadataUtil
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.chip.Chip
+import com.facebook.shimmer.ShimmerFrameLayout
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.imageview.ShapeableImageView
 import com.google.android.material.materialswitch.MaterialSwitch
 import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.google.android.material.textfield.MaterialAutoCompleteTextView
 import com.google.android.material.textfield.TextInputLayout
-import com.squareup.picasso.Picasso
 
 /**
  * Binds the music metadata section of the audio download card: the mode switch, the editable
@@ -37,6 +38,7 @@ class MusicMetadataCard(
     private val onModeChanged: (enabled: Boolean) -> Unit,
     private val onMetadataChanged: (metadata: MusicMetadata, byUser: Boolean) -> Unit,
     private val onMatchSelected: (index: Int) -> Unit,
+    private val onCoverClicked: (cover: String) -> Unit,
     private val onSearchRequested: (artist: String, song: String, providerId: String?) -> Unit
 ) {
     private val context: Context = root.context
@@ -47,6 +49,7 @@ class MusicMetadataCard(
     private val progress: CircularProgressIndicator = root.findViewById(R.id.music_progress)
     private val content: View = root.findViewById(R.id.music_content)
     private val cover: ShapeableImageView = root.findViewById(R.id.music_cover)
+    private val coverShimmer: ShimmerFrameLayout = root.findViewById(R.id.music_cover_shimmer)
     private val extra: View = root.findViewById(R.id.music_extra)
     private val matchesChip: Chip = root.findViewById(R.id.music_matches)
     private val searchChip: Chip = root.findViewById(R.id.music_manual_search)
@@ -92,7 +95,17 @@ class MusicMetadataCard(
         matchesChip.setOnClickListener { showMatchPicker() }
         searchChip.setOnClickListener { showSearchDialog() }
         detailsChip.setOnClickListener { showExtra(!extraShown) }
+        cover.setOnClickListener { onCoverClicked(current.coverUrl) }
         showExtra(false)
+        //shimmer auto starts on inflation, the card is at rest until a lookup says otherwise
+        showCoverLoading(false)
+    }
+
+    /** Replaces the artwork with one the user chose themselves, which is theirs to keep. */
+    fun setCover(cover: String) {
+        current.coverUrl = cover
+        loadCover(cover)
+        onMetadataChanged(current.copy(), true)
     }
 
     // ── State rendering ────────────────────────────────────────────────────────
@@ -107,6 +120,7 @@ class MusicMetadataCard(
     }
 
     fun showLoading() {
+        showCoverLoading(true)
         progress.isVisible(true)
         status.text = context.getString(R.string.searching_song)
         matchesChip.isEnabled = false
@@ -114,6 +128,7 @@ class MusicMetadataCard(
 
     /** The video info is still being fetched, the lookup runs as soon as it lands. */
     fun showWaiting() {
+        showCoverLoading(true)
         progress.isVisible(true)
         status.text = context.getString(R.string.waiting_for_video_info)
         matchesChip.isEnabled = false
@@ -124,6 +139,7 @@ class MusicMetadataCard(
         val metadata = all.getOrNull(selected) ?: return
         matches = all
         selectedMatch = selected
+        showCoverLoading(false)
         progress.isVisible(false)
         matchesChip.isVisible(all.size > 1)
         matchesChip.isEnabled = true
@@ -137,6 +153,7 @@ class MusicMetadataCard(
     /** No API match: keeps the parsed guess editable so the user can correct it. */
     fun showNotFound(guess: MusicMetadata) {
         matches = emptyList()
+        showCoverLoading(false)
         progress.isVisible(false)
         matchesChip.isVisible(false)
         status.text = context.getString(R.string.song_not_found)
@@ -145,6 +162,7 @@ class MusicMetadataCard(
 
     private fun showIdle() {
         matches = emptyList()
+        showCoverLoading(false)
         progress.isVisible(false)
         status.text = context.getString(R.string.music_mode_summary)
     }
@@ -168,14 +186,14 @@ class MusicMetadataCard(
         onMetadataChanged(current.copy(), false)
     }
 
+    /** The artwork is the last thing to arrive, so it shimmers for as long as the lookup runs. */
+    private fun showCoverLoading(loading: Boolean) {
+        if (loading) coverShimmer.showShimmer(true) else coverShimmer.hideShimmer()
+    }
+
     private fun loadCover(url: String) {
-        if (url.isBlank()) {
-            cover.setImageResource(R.drawable.ic_music)
-            cover.setPadding(COVER_PLACEHOLDER_PADDING)
-        } else {
-            cover.setPadding(0)
-            Picasso.get().load(url).placeholder(R.drawable.ic_music).into(cover)
-        }
+        cover.setPadding(if (url.isBlank()) COVER_PLACEHOLDER_PADDING else 0)
+        MusicCoverUtil.load(url, cover)
     }
 
     // ── Dialogs ────────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/MusicMetadataCard.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/MusicMetadataCard.kt
@@ -1,0 +1,203 @@
+package com.deniscerri.ytdl.ui.downloadcard
+
+import android.content.Context
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.EditText
+import android.widget.TextView
+import androidx.core.view.setPadding
+import com.deniscerri.ytdl.R
+import com.deniscerri.ytdl.database.models.MusicMetadata
+import com.google.android.material.card.MaterialCardView
+import com.google.android.material.chip.Chip
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.imageview.ShapeableImageView
+import com.google.android.material.materialswitch.MaterialSwitch
+import com.google.android.material.progressindicator.CircularProgressIndicator
+import com.google.android.material.textfield.TextInputLayout
+import com.squareup.picasso.Picasso
+
+/**
+ * Binds the music metadata section of the audio download card: the mode switch, the editable
+ * song fields with cover art, the alternative matches picker and the manual search dialog.
+ *
+ * The card never fetches by itself, it only reports intent through its callbacks and renders
+ * whatever state it is given.
+ */
+class MusicMetadataCard(
+    root: View,
+    private val onModeChanged: (enabled: Boolean) -> Unit,
+    private val onMetadataChanged: (MusicMetadata) -> Unit,
+    private val onSearchRequested: (artist: String, song: String) -> Unit
+) {
+    private val context: Context = root.context
+
+    private val header: MaterialCardView = root.findViewById(R.id.music_header)
+    private val switch: MaterialSwitch = root.findViewById(R.id.music_switch)
+    private val status: TextView = root.findViewById(R.id.music_status)
+    private val progress: CircularProgressIndicator = root.findViewById(R.id.music_progress)
+    private val content: View = root.findViewById(R.id.music_content)
+    private val cover: ShapeableImageView = root.findViewById(R.id.music_cover)
+    private val matchesChip: Chip = root.findViewById(R.id.music_matches)
+    private val searchChip: Chip = root.findViewById(R.id.music_manual_search)
+
+    private val songField: EditText = field(root, R.id.music_song_textinput)
+    private val artistField: EditText = field(root, R.id.music_artist_textinput)
+    private val albumField: EditText = field(root, R.id.music_album_textinput)
+    private val yearField: EditText = field(root, R.id.music_year_textinput)
+
+    private var matches: List<MusicMetadata> = emptyList()
+    private var selectedMatch = 0
+    private var current = MusicMetadata()
+    private var binding = false
+
+    val isEnabled: Boolean get() = switch.isChecked
+
+    init {
+        header.setOnClickListener { switch.isChecked = !switch.isChecked }
+        switch.setOnCheckedChangeListener { _, checked ->
+            content.isVisible(checked)
+            if (binding) return@setOnCheckedChangeListener
+            if (!checked) showIdle()
+            onModeChanged(checked)
+        }
+
+        songField.onTextChanged { current.title = it; publish() }
+        artistField.onTextChanged { current.artist = it; publish() }
+        albumField.onTextChanged { current.album = it; publish() }
+        yearField.onTextChanged { current.year = it; publish() }
+
+        matchesChip.setOnClickListener { showMatchPicker() }
+        searchChip.setOnClickListener { showSearchDialog() }
+    }
+
+    // ── State rendering ────────────────────────────────────────────────────────
+
+    /** Restores the switch without emitting a mode change. */
+    fun setChecked(checked: Boolean) {
+        if (switch.isChecked == checked) return
+        binding = true
+        switch.isChecked = checked
+        content.isVisible(checked)
+        binding = false
+    }
+
+    fun showLoading() {
+        progress.isVisible(true)
+        status.text = context.getString(R.string.searching_song)
+        matchesChip.isEnabled = false
+    }
+
+    /** Shows the resolved song, with [all] offered as alternative matches. */
+    fun showMetadata(metadata: MusicMetadata, all: List<MusicMetadata> = emptyList()) {
+        matches = all
+        selectedMatch = all.indexOfFirst { it.displayName() == metadata.displayName() }.coerceAtLeast(0)
+        progress.isVisible(false)
+        matchesChip.isVisible(all.size > 1)
+        matchesChip.isEnabled = true
+        status.text = metadata.details().ifBlank { context.getString(R.string.music_mode_summary) }
+        bindFields(metadata)
+    }
+
+    /** No API match: keeps the parsed guess editable so the user can correct it. */
+    fun showNotFound(guess: MusicMetadata) {
+        matches = emptyList()
+        progress.isVisible(false)
+        matchesChip.isVisible(false)
+        status.text = context.getString(R.string.song_not_found)
+        bindFields(guess)
+    }
+
+    private fun showIdle() {
+        matches = emptyList()
+        progress.isVisible(false)
+        status.text = context.getString(R.string.music_mode_summary)
+    }
+
+    private fun bindFields(metadata: MusicMetadata) {
+        binding = true
+        current = metadata.copy()
+        songField.setText(metadata.title)
+        artistField.setText(metadata.artist)
+        albumField.setText(metadata.album)
+        yearField.setText(metadata.year)
+        loadCover(metadata.coverUrl)
+        binding = false
+        publish()
+    }
+
+    private fun loadCover(url: String) {
+        if (url.isBlank()) {
+            cover.setImageResource(R.drawable.ic_music)
+            cover.setPadding(COVER_PLACEHOLDER_PADDING)
+        } else {
+            cover.setPadding(0)
+            Picasso.get().load(url).placeholder(R.drawable.ic_music).into(cover)
+        }
+    }
+
+    private fun publish() {
+        if (!binding) onMetadataChanged(current.copy())
+    }
+
+    // ── Dialogs ────────────────────────────────────────────────────────────────
+
+    private fun showMatchPicker() {
+        if (matches.size <= 1) return
+        val labels = matches.map { match ->
+            listOfNotNull(match.displayName(), match.details().ifBlank { null }).joinToString("\n")
+        }.toTypedArray()
+
+        MaterialAlertDialogBuilder(context)
+            .setTitle(R.string.other_matches)
+            .setSingleChoiceItems(labels, selectedMatch) { dialog, index ->
+                selectedMatch = index
+                showMetadata(matches[index], matches)
+                dialog.dismiss()
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
+    }
+
+    private fun showSearchDialog() {
+        val view = LayoutInflater.from(context).inflate(R.layout.dialog_music_search, null)
+        val artistInput = field(view, R.id.music_search_artist)
+        val songInput = field(view, R.id.music_search_song)
+        artistInput.setText(current.artist)
+        songInput.setText(current.title)
+
+        MaterialAlertDialogBuilder(context)
+            .setTitle(R.string.search_song)
+            .setView(view)
+            .setNegativeButton(R.string.cancel, null)
+            .setPositiveButton(R.string.search) { _, _ ->
+                onSearchRequested(artistInput.text.toString().trim(), songInput.text.toString().trim())
+            }
+            .show()
+    }
+
+    // ── View helpers ───────────────────────────────────────────────────────────
+
+    private fun field(root: View, id: Int): EditText =
+        root.findViewById<TextInputLayout>(id).editText!!
+
+    private fun View.isVisible(visible: Boolean) {
+        visibility = if (visible) View.VISIBLE else View.GONE
+    }
+
+    private fun EditText.onTextChanged(action: (String) -> Unit) {
+        addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+            override fun afterTextChanged(s: Editable?) {
+                if (!binding) action(s.toString().trim())
+            }
+        })
+    }
+
+    companion object {
+        private const val COVER_PLACEHOLDER_PADDING = 30
+    }
+}

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/MusicMetadataCard.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/MusicMetadataCard.kt
@@ -23,13 +23,18 @@ import com.squareup.picasso.Picasso
  * Binds the music metadata section of the audio download card: the mode switch, the editable
  * song fields with cover art, the alternative matches picker and the manual search dialog.
  *
+ * The song, the artist, the album and the year are what identifies a track, so they stay on
+ * screen. Everything else a catalogue resolves is a tag the user rarely corrects, and lives
+ * behind the details chip.
+ *
  * The card never fetches by itself, it only reports intent through its callbacks and renders
  * whatever state it is given.
  */
 class MusicMetadataCard(
-    root: View,
+    private val root: View,
     private val onModeChanged: (enabled: Boolean) -> Unit,
-    private val onMetadataChanged: (MusicMetadata) -> Unit,
+    private val onMetadataChanged: (metadata: MusicMetadata, byUser: Boolean) -> Unit,
+    private val onMatchSelected: (index: Int) -> Unit,
     private val onSearchRequested: (artist: String, song: String) -> Unit
 ) {
     private val context: Context = root.context
@@ -40,18 +45,36 @@ class MusicMetadataCard(
     private val progress: CircularProgressIndicator = root.findViewById(R.id.music_progress)
     private val content: View = root.findViewById(R.id.music_content)
     private val cover: ShapeableImageView = root.findViewById(R.id.music_cover)
+    private val extra: View = root.findViewById(R.id.music_extra)
     private val matchesChip: Chip = root.findViewById(R.id.music_matches)
     private val searchChip: Chip = root.findViewById(R.id.music_manual_search)
-
-    private val songField: EditText = field(root, R.id.music_song_textinput)
-    private val artistField: EditText = field(root, R.id.music_artist_textinput)
-    private val albumField: EditText = field(root, R.id.music_album_textinput)
-    private val yearField: EditText = field(root, R.id.music_year_textinput)
+    private val detailsChip: Chip = root.findViewById(R.id.music_details)
 
     private var matches: List<MusicMetadata> = emptyList()
     private var selectedMatch = 0
     private var current = MusicMetadata()
+    private var extraShown = false
+
+    /** Set while the card writes into its own views, so echoed edits are not read back as the users. */
     private var binding = false
+
+    /**
+     * Every editable tag, in layout order. One entry is all it takes to add a tag: the pair of
+     * accessors keeps the view and [current] in sync in both directions.
+     */
+    private val fields = listOf(
+        Field(R.id.music_song_textinput, { it.title }) { current.title = it },
+        Field(R.id.music_artist_textinput, { it.artist }) { current.artist = it },
+        Field(R.id.music_album_textinput, { it.album }) { current.album = it },
+        Field(R.id.music_year_textinput, { it.year }) { current.year = it },
+        Field(R.id.music_album_artist_textinput, { it.albumArtist }) { current.albumArtist = it },
+        Field(R.id.music_genre_textinput, { it.genre }) { current.genre = it },
+        Field(R.id.music_label_textinput, { it.label }) { current.label = it },
+        Field(R.id.music_track_textinput, { it.trackNumber }) { current.trackNumber = it },
+        Field(R.id.music_track_total_textinput, { it.trackTotal }) { current.trackTotal = it },
+        Field(R.id.music_disc_textinput, { it.discNumber }) { current.discNumber = it },
+        Field(R.id.music_isrc_textinput, { it.isrc }) { current.isrc = it }
+    )
 
     val isEnabled: Boolean get() = switch.isChecked
 
@@ -64,13 +87,10 @@ class MusicMetadataCard(
             onModeChanged(checked)
         }
 
-        songField.onTextChanged { current.title = it; publish() }
-        artistField.onTextChanged { current.artist = it; publish() }
-        albumField.onTextChanged { current.album = it; publish() }
-        yearField.onTextChanged { current.year = it; publish() }
-
         matchesChip.setOnClickListener { showMatchPicker() }
         searchChip.setOnClickListener { showSearchDialog() }
+        detailsChip.setOnClickListener { showExtra(!extraShown) }
+        showExtra(false)
     }
 
     // ── State rendering ────────────────────────────────────────────────────────
@@ -90,16 +110,27 @@ class MusicMetadataCard(
         matchesChip.isEnabled = false
     }
 
-    /** Shows the resolved song, with [all] offered as alternative matches. */
-    fun showMetadata(metadata: MusicMetadata, all: List<MusicMetadata> = emptyList()) {
+    /** The video info is still being fetched, the lookup runs as soon as it lands. */
+    fun showWaiting() {
+        progress.isVisible(true)
+        status.text = context.getString(R.string.waiting_for_video_info)
+        matchesChip.isEnabled = false
+    }
+
+    /** Shows [selected] out of the resolved [all], which the picker offers as alternatives. */
+    fun showMetadata(all: List<MusicMetadata>, selected: Int) {
+        val metadata = all.getOrNull(selected) ?: return
         matches = all
-        selectedMatch = all.indexOfFirst { it.displayName() == metadata.displayName() }.coerceAtLeast(0)
+        selectedMatch = selected
         progress.isVisible(false)
         matchesChip.isVisible(all.size > 1)
         matchesChip.isEnabled = true
         status.text = metadata.details().ifBlank { context.getString(R.string.music_mode_summary) }
         bindFields(metadata)
     }
+
+    /** A settled song with no alternatives, restored from the download item. */
+    fun showMetadata(metadata: MusicMetadata) = showMetadata(listOf(metadata), 0)
 
     /** No API match: keeps the parsed guess editable so the user can correct it. */
     fun showNotFound(guess: MusicMetadata) {
@@ -116,16 +147,23 @@ class MusicMetadataCard(
         status.text = context.getString(R.string.music_mode_summary)
     }
 
+    private fun showExtra(show: Boolean) {
+        extraShown = show
+        extra.isVisible(show)
+        detailsChip.setText(if (show) R.string.fewer_details else R.string.more_details)
+        detailsChip.setChipIconResource(
+            if (show) R.drawable.baseline_expand_less_24 else R.drawable.baseline_expand_more_24
+        )
+    }
+
     private fun bindFields(metadata: MusicMetadata) {
         binding = true
         current = metadata.copy()
-        songField.setText(metadata.title)
-        artistField.setText(metadata.artist)
-        albumField.setText(metadata.album)
-        yearField.setText(metadata.year)
+        fields.forEach { it.show(metadata) }
         loadCover(metadata.coverUrl)
         binding = false
-        publish()
+        //rendered state is never the users own, only typing in a field is
+        onMetadataChanged(current.copy(), false)
     }
 
     private fun loadCover(url: String) {
@@ -136,10 +174,6 @@ class MusicMetadataCard(
             cover.setPadding(0)
             Picasso.get().load(url).placeholder(R.drawable.ic_music).into(cover)
         }
-    }
-
-    private fun publish() {
-        if (!binding) onMetadataChanged(current.copy())
     }
 
     // ── Dialogs ────────────────────────────────────────────────────────────────
@@ -153,8 +187,7 @@ class MusicMetadataCard(
         MaterialAlertDialogBuilder(context)
             .setTitle(R.string.other_matches)
             .setSingleChoiceItems(labels, selectedMatch) { dialog, index ->
-                selectedMatch = index
-                showMetadata(matches[index], matches)
+                onMatchSelected(index)
                 dialog.dismiss()
             }
             .setNegativeButton(R.string.cancel, null)
@@ -163,8 +196,8 @@ class MusicMetadataCard(
 
     private fun showSearchDialog() {
         val view = LayoutInflater.from(context).inflate(R.layout.dialog_music_search, null)
-        val artistInput = field(view, R.id.music_search_artist)
-        val songInput = field(view, R.id.music_search_song)
+        val artistInput = input(view, R.id.music_search_artist)
+        val songInput = input(view, R.id.music_search_song)
         artistInput.setText(current.artist)
         songInput.setText(current.title)
 
@@ -180,21 +213,34 @@ class MusicMetadataCard(
 
     // ── View helpers ───────────────────────────────────────────────────────────
 
-    private fun field(root: View, id: Int): EditText =
+    /** One editable tag: renders it from a metadata and writes edits straight back into [current]. */
+    private inner class Field(
+        id: Int,
+        private val read: (MusicMetadata) -> String,
+        private val write: (String) -> Unit
+    ) {
+        private val view: EditText = input(root, id)
+
+        init {
+            view.addTextChangedListener(object : TextWatcher {
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+                override fun afterTextChanged(s: Editable?) {
+                    if (binding) return
+                    write(s.toString().trim())
+                    onMetadataChanged(current.copy(), true)
+                }
+            })
+        }
+
+        fun show(metadata: MusicMetadata) = view.setText(read(metadata))
+    }
+
+    private fun input(root: View, id: Int): EditText =
         root.findViewById<TextInputLayout>(id).editText!!
 
     private fun View.isVisible(visible: Boolean) {
         visibility = if (visible) View.VISIBLE else View.GONE
-    }
-
-    private fun EditText.onTextChanged(action: (String) -> Unit) {
-        addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
-            override fun afterTextChanged(s: Editable?) {
-                if (!binding) action(s.toString().trim())
-            }
-        })
     }
 
     companion object {

--- a/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/ObserveSourcesBottomSheetDialog.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/downloadcard/ObserveSourcesBottomSheetDialog.kt
@@ -19,7 +19,6 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.content.edit
 import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
@@ -187,12 +186,6 @@ class ObserveSourcesBottomSheetDialog : BottomSheetDialogFragment() {
             }
         }
 
-        sharedPreferences.edit(commit = true) {
-            putString("last_used_download_type",
-                type.toString())
-        }
-
-
         tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab?) {
                 if (tab!!.position == 2 && commandTemplateNr == 0){
@@ -230,12 +223,6 @@ class ObserveSourcesBottomSheetDialog : BottomSheetDialogFragment() {
         viewPager2.registerOnPageChangeCallback(object: ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 tabLayout.selectTab(tabLayout.getTabAt(position))
-                runCatching {
-                    sharedPreferences.edit(commit = true) {
-                        putString("last_used_download_type",
-                            listOf(DownloadType.audio, DownloadType.video, DownloadType.command)[position].toString())
-                    }
-                }
             }
         })
 

--- a/app/src/main/java/com/deniscerri/ytdl/util/LastUsedDownloadSettings.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/LastUsedDownloadSettings.kt
@@ -1,0 +1,91 @@
+package com.deniscerri.ytdl.util
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.deniscerri.ytdl.database.enums.DownloadType
+import com.deniscerri.ytdl.database.models.AudioPreferences
+import com.deniscerri.ytdl.database.models.DownloadItem
+import com.deniscerri.ytdl.database.models.Format
+import com.deniscerri.ytdl.database.models.VideoPreferences
+import com.google.gson.Gson
+
+/**
+ * Remembers how the user configured their last download of each type and seeds the next one
+ * with it, so the download card opens in the state it was left in.
+ *
+ * Stored as one snapshot per [DownloadType]. Only card level choices are kept: values that
+ * belong to a single video (cut sections, crop, resolved music tags) and values that are a
+ * projection of the app settings (the filename template) are deliberately left out, so the
+ * settings screens stay authoritative over them.
+ */
+object LastUsedDownloadSettings {
+    private const val KEY = "last_used_settings_"
+    private val gson = Gson()
+
+    private data class Snapshot(
+        val website: String = "",
+        val container: String = "",
+        val downloadPath: String = "",
+        val formatId: String = "",
+        val saveThumb: Boolean = false,
+        val audio: AudioPreferences? = null,
+        val video: VideoPreferences? = null
+    )
+
+    fun save(preferences: SharedPreferences, item: DownloadItem) {
+        val snapshot = Snapshot(
+            website = item.website,
+            container = item.container,
+            downloadPath = item.downloadPath,
+            formatId = item.format.format_id,
+            saveThumb = item.SaveThumb,
+            audio = if (item.type == DownloadType.audio) {
+                item.audioPreferences.copy(musicMetadata = null)
+            } else null,
+            video = if (item.type == DownloadType.video) {
+                item.videoPreferences.copy(cropValues = "")
+            } else null
+        )
+        preferences.edit { putString(KEY + item.type, gson.toJson(snapshot)) }
+    }
+
+    /** Seeds a freshly created item with the last used configuration of its type. */
+    fun apply(preferences: SharedPreferences, item: DownloadItem) {
+        val snapshot = read(preferences, item.type) ?: return
+
+        item.container = snapshot.container
+        item.SaveThumb = snapshot.saveThumb
+        snapshot.downloadPath.takeIf { it.isNotBlank() }?.let { item.downloadPath = it }
+
+        when (item.type) {
+            DownloadType.audio -> snapshot.audio?.let { item.audioPreferences = it.copy() }
+            DownloadType.video -> snapshot.video?.let { item.videoPreferences = it.copy(
+                audioFormatIDs = item.keepKnownFormats(it.audioFormatIDs)
+                    .ifEmpty { item.videoPreferences.audioFormatIDs }
+            ) }
+            else -> {}
+        }
+
+        rememberedFormat(preferences, item, item.allFormats)?.let { item.format = it }
+    }
+
+    /**
+     * The last used format, but only when it exists in [formats] and comes from the same site,
+     * since a format id only means the same thing on the site it came from.
+     *
+     * Formats are usually fetched after the card is built, so this is also used once they land.
+     */
+    fun rememberedFormat(preferences: SharedPreferences, item: DownloadItem, formats: List<Format>): Format? {
+        val snapshot = read(preferences, item.type) ?: return null
+        if (snapshot.website != item.website || snapshot.formatId.isBlank()) return null
+        return formats.firstOrNull { it.format_id == snapshot.formatId }
+    }
+
+    /** A snapshot written by an older version may no longer parse, the defaults then stand. */
+    private fun read(preferences: SharedPreferences, type: DownloadType): Snapshot? = runCatching {
+        gson.fromJson(preferences.getString(KEY + type, null), Snapshot::class.java)
+    }.getOrNull()
+
+    private fun DownloadItem.keepKnownFormats(ids: List<String>) =
+        ArrayList(ids.filter { id -> allFormats.any { it.format_id == id } })
+}

--- a/app/src/main/java/com/deniscerri/ytdl/util/LastUsedDownloadSettings.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/LastUsedDownloadSettings.kt
@@ -13,13 +13,17 @@ import com.google.gson.Gson
  * Remembers how the user configured their last download of each type and seeds the next one
  * with it, so the download card opens in the state it was left in.
  *
- * Stored as one snapshot per [DownloadType]. Only card level choices are kept: values that
- * belong to a single video (cut sections, crop, resolved music tags) and values that are a
- * projection of the app settings (the filename template) are deliberately left out, so the
- * settings screens stay authoritative over them.
+ * Stored as one snapshot per [DownloadType], plus the type itself so the card also reopens on
+ * the tab that was last downloaded from. A snapshot is written only when a download is actually
+ * committed: opening the card or swiping through its tabs is browsing, not a choice.
+ *
+ * Only card level choices are kept: values that belong to a single video (cut sections, crop,
+ * resolved music tags) and values that are a projection of the app settings (the filename
+ * template) are deliberately left out, so the settings screens stay authoritative over them.
  */
 object LastUsedDownloadSettings {
-    private const val KEY = "last_used_settings_"
+    private const val SNAPSHOT_KEY = "last_used_settings_"
+    private const val TYPE_KEY = "last_used_download_type"
     private val gson = Gson()
 
     private data class Snapshot(
@@ -32,6 +36,7 @@ object LastUsedDownloadSettings {
         val video: VideoPreferences? = null
     )
 
+    /** Call when a download is committed, never when the card is merely opened or browsed. */
     fun save(preferences: SharedPreferences, item: DownloadItem) {
         val snapshot = Snapshot(
             website = item.website,
@@ -46,7 +51,10 @@ object LastUsedDownloadSettings {
                 item.videoPreferences.copy(cropValues = "")
             } else null
         )
-        preferences.edit { putString(KEY + item.type, gson.toJson(snapshot)) }
+        preferences.edit {
+            putString(SNAPSHOT_KEY + item.type, gson.toJson(snapshot))
+            putString(TYPE_KEY, item.type.toString())
+        }
     }
 
     /** Seeds a freshly created item with the last used configuration of its type. */
@@ -81,9 +89,15 @@ object LastUsedDownloadSettings {
         return formats.firstOrNull { it.format_id == snapshot.formatId }
     }
 
+    /** The type of the last committed download, null while there is none to fall back on. */
+    fun lastType(preferences: SharedPreferences): DownloadType? = runCatching {
+        DownloadType.valueOf(preferences.getString(TYPE_KEY, "")!!)
+            .takeIf { it != DownloadType.auto }
+    }.getOrNull()
+
     /** A snapshot written by an older version may no longer parse, the defaults then stand. */
     private fun read(preferences: SharedPreferences, type: DownloadType): Snapshot? = runCatching {
-        gson.fromJson(preferences.getString(KEY + type, null), Snapshot::class.java)
+        gson.fromJson(preferences.getString(SNAPSHOT_KEY + type, null), Snapshot::class.java)
     }.getOrNull()
 
     private fun DownloadItem.keepKnownFormats(ids: List<String>) =

--- a/app/src/main/java/com/deniscerri/ytdl/util/MusicCoverUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/MusicCoverUtil.kt
@@ -1,0 +1,106 @@
+package com.deniscerri.ytdl.util
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.util.Log
+import android.widget.ImageView
+import androidx.core.net.toUri
+import com.deniscerri.ytdl.R
+import com.deniscerri.ytdl.util.extractors.music.MusicHttp
+import com.squareup.picasso.Picasso
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlin.math.max
+
+/**
+ * Handles the album cover of a music download, wherever it comes from: a catalogue url, a
+ * picture the user picked on the device, or nothing at all.
+ *
+ * A picked image is copied into app storage instead of being referenced. The download runs
+ * long after the picker handed out its permission, and the document it points at may be gone
+ * or unreadable by then, so the bytes are taken while they are still there to take.
+ */
+object MusicCoverUtil {
+    private const val TAG = "MusicCoverUtil"
+    private const val DIR = "music_covers"
+
+    /** Picked covers outlive their download by a week, long enough to survive a retry. */
+    private val MAX_AGE_MS = TimeUnit.DAYS.toMillis(7)
+
+    /** @return the stored path to keep as the cover, or null when the image could not be read. */
+    fun store(context: Context, uri: Uri): String? = runCatching {
+        val dir = File(context.filesDir, DIR).apply { mkdirs(); prune() }
+        val file = File(dir, "cover_${System.currentTimeMillis()}.jpg")
+        context.contentResolver.openInputStream(uri)!!.use { source ->
+            file.outputStream().use { source.copyTo(it) }
+        }
+        file.absolutePath
+    }.getOrElse { Log.w(TAG, "Could not store the picked cover", it); null }
+
+    /** A stored cover is an absolute path, a catalogue one is always a url. */
+    fun isLocal(cover: String): Boolean = cover.startsWith("/")
+
+    /** Renders a catalogue cover into the card thumbnail, where the http cache earns its keep. */
+    fun load(cover: String, target: ImageView) {
+        if (cover.isBlank()) {
+            target.setImageResource(R.drawable.ic_music)
+            return
+        }
+        val request = if (isLocal(cover)) Picasso.get().load(File(cover)) else Picasso.get().load(cover)
+        request.placeholder(R.drawable.ic_music).into(target)
+    }
+
+    /**
+     * Decodes a cover at full size for the preview, whatever it is: a stored file, a catalogue
+     * url or a document the user just picked.
+     *
+     * Read straight from the source rather than through the image cache. A preview is looked at
+     * once and decided on, and a picked document is only readable while its grant lasts, so
+     * there is nothing here worth caching and nothing worth risking on a stale handle.
+     *
+     * @param maxSize the longest edge to decode down to, covers are routinely larger than a screen.
+     * @return the bitmap, or null when the source is empty or unreadable.
+     */
+    suspend fun preview(context: Context, cover: String, maxSize: Int): Bitmap? =
+        withContext(Dispatchers.IO) {
+            if (cover.isBlank()) return@withContext null
+            runCatching {
+                val bytes = open(context, cover) ?: return@withContext null
+
+                val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+
+                val options = BitmapFactory.Options().apply {
+                    inSampleSize = sampleSize(bounds.outWidth, bounds.outHeight, maxSize)
+                }
+                BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options)
+            }.getOrElse { Log.w(TAG, "Could not read the cover", it); null }
+        }
+
+    /** The three shapes a cover comes in, each read once into memory so it can be measured then decoded. */
+    private fun open(context: Context, cover: String): ByteArray? = when {
+        isLocal(cover) -> File(cover).takeIf { it.exists() }?.readBytes()
+        cover.startsWith("http") -> MusicHttp.bytes(cover)
+        else -> context.contentResolver.openInputStream(cover.toUri())?.use { it.readBytes() }
+    }
+
+    /**
+     * Halving is the only reduction [BitmapFactory] does, so stop one step before the image
+     * would drop under [maxSize]: a preview that is a little large costs memory once, one that
+     * is too small looks soft for as long as it is on screen.
+     */
+    private fun sampleSize(width: Int, height: Int, maxSize: Int): Int {
+        var sample = 1
+        while (max(width, height) / (sample * 2) >= maxSize) sample *= 2
+        return sample
+    }
+
+    private fun File.prune() {
+        val expiry = System.currentTimeMillis() - MAX_AGE_MS
+        listFiles()?.filter { it.lastModified() < expiry }?.forEach { it.delete() }
+    }
+}

--- a/app/src/main/java/com/deniscerri/ytdl/util/MusicTagUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/MusicTagUtil.kt
@@ -1,0 +1,88 @@
+package com.deniscerri.ytdl.util
+
+import android.util.Log
+import com.deniscerri.ytdl.database.models.MusicMetadata
+import com.deniscerri.ytdl.util.extractors.music.MusicMetadataUtil
+import org.jaudiotagger.audio.AudioFileIO
+import org.jaudiotagger.tag.FieldKey
+import org.jaudiotagger.tag.images.ArtworkFactory
+import java.io.File
+import java.util.logging.Level
+import java.util.logging.Logger
+
+/**
+ * Writes the resolved [MusicMetadata] into finished audio files and renames them to
+ * "Artist - Title.ext". Runs on the downloaded file before it is moved to its final
+ * destination, so tagging never touches SAF trees.
+ */
+object MusicTagUtil {
+    private const val TAG = "MusicTagUtil"
+
+    /** Containers jaudiotagger can write tags into. Others are only renamed. */
+    private val TAGGABLE = setOf("mp3", "m4a", "m4b", "mp4", "flac", "ogg", "wav", "aif", "aiff", "wma")
+
+    init {
+        Logger.getLogger("org.jaudiotagger").level = Level.OFF
+    }
+
+    /** Tags + renames every audio file inside [dir] (cache download, pre-move). */
+    fun applyToDirectory(dir: File, metadata: MusicMetadata) {
+        val files = dir.walkTopDown().filter { it.isFile && it.extension.lowercase() in TAGGABLE }.toList()
+        apply(files, metadata)
+    }
+
+    /** Tags + renames files already written to their destination, returning the updated paths. */
+    fun applyToPaths(paths: List<String>, metadata: MusicMetadata): List<String> {
+        val files = paths.map { File(it) }
+        val renamed = apply(files, metadata).associate { (from, to) -> from to to }
+        return paths.map { renamed[it] ?: it }
+    }
+
+    /** @return pairs of (old path, new path) for the files that were renamed. */
+    private fun apply(files: List<File>, metadata: MusicMetadata): List<Pair<String, String>> {
+        if (files.isEmpty() || !metadata.isUsable) return emptyList()
+
+        val cover = metadata.coverUrl.takeIf { it.isNotBlank() }?.let { downloadCover(it) }
+        val renames = mutableListOf<Pair<String, String>>()
+
+        files.forEach { file ->
+            if (file.extension.lowercase() in TAGGABLE) {
+                runCatching { writeTags(file, metadata, cover) }
+                    .onFailure { Log.w(TAG, "Tagging failed for ${file.name}", it) }
+            }
+            renameToCleanName(file, metadata)?.let { renames.add(file.absolutePath to it) }
+        }
+
+        cover?.delete()
+        return renames
+    }
+
+    private fun writeTags(file: File, metadata: MusicMetadata, cover: File?) {
+        val audioFile = AudioFileIO.read(file)
+        val tag = audioFile.tagOrCreateDefault
+        tag.setField(FieldKey.TITLE, metadata.title)
+        tag.setField(FieldKey.ARTIST, metadata.artist)
+        tag.setField(FieldKey.ALBUM_ARTIST, metadata.artist)
+        metadata.album.takeIf { it.isNotBlank() }?.let { tag.setField(FieldKey.ALBUM, it) }
+        metadata.year.takeIf { it.isNotBlank() }?.let { tag.setField(FieldKey.YEAR, it) }
+        metadata.genre.takeIf { it.isNotBlank() }?.let { tag.setField(FieldKey.GENRE, it) }
+        cover?.let {
+            tag.deleteArtworkField()
+            tag.setField(ArtworkFactory.createArtworkFromFile(it))
+        }
+        audioFile.tag = tag
+        AudioFileIO.write(audioFile)
+    }
+
+    /** @return the new absolute path, or null when the file was left untouched. */
+    private fun renameToCleanName(file: File, metadata: MusicMetadata): String? {
+        val target = File(file.parentFile, MusicMetadataUtil.buildFileName(metadata, file.extension))
+        if (target.absolutePath == file.absolutePath || target.exists()) return null
+        return if (file.renameTo(target)) target.absolutePath else null
+    }
+
+    private fun downloadCover(url: String): File? = runCatching {
+        val bytes = MusicMetadataUtil.downloadBytes(url) ?: return null
+        File.createTempFile("cover_", ".jpg").apply { writeBytes(bytes) }
+    }.getOrElse { Log.w(TAG, "Cover download failed", it); null }
+}

--- a/app/src/main/java/com/deniscerri/ytdl/util/MusicTagUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/MusicTagUtil.kt
@@ -44,20 +44,32 @@ object MusicTagUtil {
     private fun apply(files: List<File>, metadata: MusicMetadata): List<Pair<String, String>> {
         if (files.isEmpty() || !metadata.isUsable) return emptyList()
 
-        val cover = metadata.coverUrl.takeIf { it.isNotBlank() }?.let { downloadCover(it) }
+        val cover = metadata.coverUrl.takeIf { it.isNotBlank() }?.let { resolveCover(it) }
         val renames = mutableListOf<Pair<String, String>>()
 
         files.forEach { file ->
             if (file.extension.lowercase() in TAGGABLE) {
-                runCatching { writeTags(file, metadata, cover) }
+                runCatching { writeTags(file, metadata, cover?.file) }
                     .onFailure { Log.w(TAG, "Tagging failed for ${file.name}", it) }
             }
             renameToCleanName(file, metadata)?.let { renames.add(file.absolutePath to it) }
         }
 
-        cover?.delete()
+        //only the copy this run made is ours to remove, a picked cover belongs to the user
+        if (cover?.temporary == true) cover.file.delete()
         return renames
     }
+
+    /** The artwork to embed, and whether embedding it is the last thing it is needed for. */
+    private class Cover(val file: File, val temporary: Boolean)
+
+    private fun resolveCover(cover: String): Cover? = runCatching {
+        if (MusicCoverUtil.isLocal(cover)) {
+            return File(cover).takeIf { it.exists() }?.let { Cover(it, temporary = false) }
+        }
+        val bytes = MusicHttp.bytes(cover) ?: return null
+        Cover(File.createTempFile("cover_", ".jpg").apply { writeBytes(bytes) }, temporary = true)
+    }.getOrElse { Log.w(TAG, "Cover unavailable", it); null }
 
     private fun writeTags(file: File, metadata: MusicMetadata, cover: File?) {
         val audioFile = AudioFileIO.read(file)
@@ -96,9 +108,4 @@ object MusicTagUtil {
         if (target.absolutePath == file.absolutePath || target.exists()) return null
         return if (file.renameTo(target)) target.absolutePath else null
     }
-
-    private fun downloadCover(url: String): File? = runCatching {
-        val bytes = MusicHttp.bytes(url) ?: return null
-        File.createTempFile("cover_", ".jpg").apply { writeBytes(bytes) }
-    }.getOrElse { Log.w(TAG, "Cover download failed", it); null }
 }

--- a/app/src/main/java/com/deniscerri/ytdl/util/MusicTagUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/MusicTagUtil.kt
@@ -2,9 +2,11 @@ package com.deniscerri.ytdl.util
 
 import android.util.Log
 import com.deniscerri.ytdl.database.models.MusicMetadata
+import com.deniscerri.ytdl.util.extractors.music.MusicHttp
 import com.deniscerri.ytdl.util.extractors.music.MusicMetadataUtil
 import org.jaudiotagger.audio.AudioFileIO
 import org.jaudiotagger.tag.FieldKey
+import org.jaudiotagger.tag.Tag
 import org.jaudiotagger.tag.images.ArtworkFactory
 import java.io.File
 import java.util.logging.Level
@@ -62,16 +64,30 @@ object MusicTagUtil {
         val tag = audioFile.tagOrCreateDefault
         tag.setField(FieldKey.TITLE, metadata.title)
         tag.setField(FieldKey.ARTIST, metadata.artist)
-        tag.setField(FieldKey.ALBUM_ARTIST, metadata.artist)
-        metadata.album.takeIf { it.isNotBlank() }?.let { tag.setField(FieldKey.ALBUM, it) }
-        metadata.year.takeIf { it.isNotBlank() }?.let { tag.setField(FieldKey.YEAR, it) }
-        metadata.genre.takeIf { it.isNotBlank() }?.let { tag.setField(FieldKey.GENRE, it) }
+        tag.write(FieldKey.ALBUM_ARTIST, metadata.albumArtist.ifBlank { metadata.artist })
+        tag.write(FieldKey.ALBUM, metadata.album)
+        tag.write(FieldKey.YEAR, metadata.year)
+        tag.write(FieldKey.GENRE, metadata.genre)
+        tag.write(FieldKey.RECORD_LABEL, metadata.label)
+        tag.write(FieldKey.TRACK, metadata.trackNumber)
+        tag.write(FieldKey.TRACK_TOTAL, metadata.trackTotal)
+        tag.write(FieldKey.DISC_NO, metadata.discNumber)
+        tag.write(FieldKey.ISRC, metadata.isrc)
         cover?.let {
             tag.deleteArtworkField()
             tag.setField(ArtworkFactory.createArtworkFromFile(it))
         }
         audioFile.tag = tag
         AudioFileIO.write(audioFile)
+    }
+
+    /**
+     * Writes an optional tag, skipping the blanks so an unresolved field never wipes what the
+     * downloader already wrote, and tolerating the keys a given container cannot store.
+     */
+    private fun Tag.write(key: FieldKey, value: String) {
+        if (value.isBlank()) return
+        runCatching { setField(key, value) }.onFailure { Log.w(TAG, "Unsupported tag $key", it) }
     }
 
     /** @return the new absolute path, or null when the file was left untouched. */
@@ -82,7 +98,7 @@ object MusicTagUtil {
     }
 
     private fun downloadCover(url: String): File? = runCatching {
-        val bytes = MusicMetadataUtil.downloadBytes(url) ?: return null
+        val bytes = MusicHttp.bytes(url) ?: return null
         File.createTempFile("cover_", ".jpg").apply { writeBytes(bytes) }
     }.getOrElse { Log.w(TAG, "Cover download failed", it); null }
 }

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/DeezerProvider.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/DeezerProvider.kt
@@ -1,0 +1,59 @@
+package com.deniscerri.ytdl.util.extractors.music
+
+import com.deniscerri.ytdl.database.models.MusicMetadata
+import com.deniscerri.ytdl.database.models.MusicSource
+import com.google.gson.JsonObject
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+
+/**
+ * Deezer, the primary catalogue: it covers non english releases well and needs no key.
+ *
+ * Its search endpoint only carries the song, the artist, the ISRC and the album cover. The
+ * release year and the track numbering live on the track resource, the genre, the label and
+ * the album artist on the album resource, so [details] reads both, in parallel.
+ */
+object DeezerProvider : MusicProvider {
+
+    private const val API = "https://api.deezer.com"
+
+    override val id = "deezer"
+
+    override suspend fun search(query: String, limit: Int): List<MusicMetadata> {
+        val body = MusicHttp.json("$API/search?q=${MusicHttp.encode(query)}&limit=$limit") ?: return emptyList()
+        return body.arr("data").map { it.asJsonObject.toMetadata() }.filter { it.isUsable }
+    }
+
+    override suspend fun details(metadata: MusicMetadata): MusicMetadata = coroutineScope {
+        val source = metadata.source ?: return@coroutineScope metadata
+        val track = async { MusicHttp.json("$API/track/${source.trackId}") }
+        val album = async { MusicHttp.json("$API/album/${source.albumId}") }
+        metadata.completedWith(track.await(), album.await())
+    }
+
+    private fun JsonObject.toMetadata(): MusicMetadata {
+        val album = obj("album")
+        return MusicMetadata(
+            title = str("title"),
+            artist = obj("artist")?.str("name").orEmpty(),
+            album = album?.str("title").orEmpty(),
+            isrc = str("isrc"),
+            coverUrl = album?.str("cover_xl").orEmpty(),
+            source = MusicSource(id, str("id"), album?.str("id").orEmpty())
+        )
+    }
+
+    /** Both resources are optional: whichever one answered contributes what it knows. */
+    private fun MusicMetadata.completedWith(track: JsonObject?, album: JsonObject?) = copy(
+        year = firstNonBlank(track?.str("release_date"), album?.str("release_date")).take(YEAR_LENGTH),
+        albumArtist = album?.obj("artist")?.str("name").orEmpty(),
+        genre = album?.obj("genres")?.arr("data")?.firstOrNull()?.asJsonObject?.str("name").orEmpty(),
+        label = album?.str("label").orEmpty(),
+        trackNumber = track?.str("track_position").orEmpty(),
+        trackTotal = album?.str("nb_tracks").orEmpty(),
+        discNumber = track?.str("disk_number").orEmpty()
+    )
+
+    /** Release dates arrive as "2001-03-12", only the year is a tag. */
+    private const val YEAR_LENGTH = 4
+}

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/DeezerProvider.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/DeezerProvider.kt
@@ -18,6 +18,7 @@ object DeezerProvider : MusicProvider {
     private const val API = "https://api.deezer.com"
 
     override val id = "deezer"
+    override val name = "Deezer"
 
     override suspend fun search(query: String, limit: Int): List<MusicMetadata> {
         val body = MusicHttp.json("$API/search?q=${MusicHttp.encode(query)}&limit=$limit") ?: return emptyList()

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/ItunesProvider.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/ItunesProvider.kt
@@ -20,6 +20,7 @@ object ItunesProvider : MusicProvider {
     private const val YEAR_LENGTH = 4
 
     override val id = "itunes"
+    override val name = "iTunes"
 
     override suspend fun search(query: String, limit: Int): List<MusicMetadata> {
         val body = MusicHttp.json("$API/search?term=${MusicHttp.encode(query)}&entity=song&limit=$limit")

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/ItunesProvider.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/ItunesProvider.kt
@@ -1,0 +1,44 @@
+package com.deniscerri.ytdl.util.extractors.music
+
+import com.deniscerri.ytdl.database.models.MusicMetadata
+import com.deniscerri.ytdl.database.models.MusicSource
+import com.google.gson.JsonObject
+
+/**
+ * iTunes, the fallback catalogue, queried when Deezer knows nothing about the song.
+ *
+ * Its search endpoint returns the full record in one response, so there is nothing left for
+ * [details] to complete. It carries no label and no ISRC, those tags simply stay blank.
+ */
+object ItunesProvider : MusicProvider {
+
+    private const val API = "https://itunes.apple.com"
+
+    /** The search artwork is a thumbnail, the same url serves the full size cover. */
+    private const val THUMBNAIL_SIZE = "100x100bb"
+    private const val COVER_SIZE = "1200x1200bb"
+    private const val YEAR_LENGTH = 4
+
+    override val id = "itunes"
+
+    override suspend fun search(query: String, limit: Int): List<MusicMetadata> {
+        val body = MusicHttp.json("$API/search?term=${MusicHttp.encode(query)}&entity=song&limit=$limit")
+            ?: return emptyList()
+        return body.arr("results").map { it.asJsonObject.toMetadata() }.filter { it.isUsable }
+    }
+
+    private fun JsonObject.toMetadata() = MusicMetadata(
+        title = str("trackName"),
+        artist = str("artistName"),
+        album = str("collectionName"),
+        year = str("releaseDate").take(YEAR_LENGTH),
+        //compilations name their album artist, single artist releases leave it out
+        albumArtist = firstNonBlank(str("collectionArtistName"), str("artistName")),
+        genre = str("primaryGenreName"),
+        trackNumber = str("trackNumber"),
+        trackTotal = str("trackCount"),
+        discNumber = str("discNumber"),
+        coverUrl = str("artworkUrl100").replace(THUMBNAIL_SIZE, COVER_SIZE),
+        source = MusicSource(id)
+    )
+}

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicHttp.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicHttp.kt
@@ -1,0 +1,48 @@
+package com.deniscerri.ytdl.util.extractors.music
+
+import android.util.Log
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.net.URLEncoder
+import java.util.concurrent.TimeUnit
+
+/**
+ * The single network entry point of the music package, shared by every provider so they all
+ * get the same client, timeouts and failure handling.
+ *
+ * Every call blocks and every failure is swallowed into a null: a catalogue being unreachable
+ * is a normal outcome here, the lookup simply falls through to the next one.
+ */
+object MusicHttp {
+    private const val TAG = "MusicHttp"
+    private const val TIMEOUT_SECONDS = 8L
+    private const val USER_AGENT = "Mozilla/5.0"
+
+    private val client by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .build()
+    }
+
+    fun encode(value: String): String = URLEncoder.encode(value, "UTF-8")
+
+    /** The parsed response body, or null when the request, the response or the parsing failed. */
+    fun json(url: String): JsonObject? = runCatching {
+        JsonParser.parseString(get(url) ?: return null).asJsonObject
+    }.getOrElse { Log.w(TAG, "Parsing failed: $url", it); null }
+
+    fun bytes(url: String): ByteArray? = runCatching {
+        call(url).use { if (it.isSuccessful) it.body.bytes() else null }
+    }.getOrElse { Log.w(TAG, "Download failed: $url", it); null }
+
+    private fun get(url: String): String? = runCatching {
+        call(url).use { if (it.isSuccessful) it.body.string() else null }
+    }.getOrElse { Log.w(TAG, "Request failed: $url", it); null }
+
+    private fun call(url: String) = client
+        .newCall(Request.Builder().url(url).header("User-Agent", USER_AGENT).build())
+        .execute()
+}

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicMetadataUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicMetadataUtil.kt
@@ -142,13 +142,24 @@ object MusicMetadataUtil {
      */
     private val providers = listOf(DeezerProvider, ItunesProvider)
 
-    /** Explicit search, used by the manual "artist + song" lookup. */
-    suspend fun search(artist: String, title: String, limit: Int = MATCH_LIMIT): List<MusicMetadata> =
-        withContext(Dispatchers.IO) {
-            val query = listOf(artist, title).filter { it.isNotBlank() }.joinToString(" ")
-            if (query.isBlank()) return@withContext emptyList()
-            providers.firstNotNullOfOrNull { it.search(query, limit).ifEmpty { null } }.orEmpty()
-        }
+    /** Id to brand name, in lookup order. Fills the catalogue picker of the manual search. */
+    val catalogues: List<Pair<String, String>> = providers.map { it.id to it.name }
+
+    /**
+     * Explicit search, used by the manual "artist + song" lookup. [providerId] narrows it to a
+     * single catalogue, null consults them all in order.
+     */
+    suspend fun search(
+        artist: String,
+        title: String,
+        providerId: String? = null,
+        limit: Int = MATCH_LIMIT
+    ): List<MusicMetadata> = withContext(Dispatchers.IO) {
+        val query = listOf(artist, title).filter { it.isNotBlank() }.joinToString(" ")
+        if (query.isBlank()) return@withContext emptyList()
+        val chosen = providerId?.let { id -> providers.filter { it.id == id } } ?: providers
+        chosen.firstNotNullOfOrNull { it.search(query, limit).ifEmpty { null } }.orEmpty()
+    }
 
     /**
      * Automatic lookup from the fetched video info. Tries every parsed candidate and
@@ -158,7 +169,7 @@ object MusicMetadataUtil {
         withContext(Dispatchers.IO) {
             buildSearchQueries(videoTitle, uploader)
                 .firstNotNullOfOrNull { (artist, title) ->
-                    search(artist, title, limit).ifEmpty { null }
+                    search(artist, title, limit = limit).ifEmpty { null }
                 }
                 ?.map { enrichWithFeaturing(it, videoTitle) }
                 .orEmpty()

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicMetadataUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicMetadataUtil.kt
@@ -151,14 +151,14 @@ object MusicMetadataUtil {
     internal fun httpGet(url: String): String? = runCatching {
         val request = Request.Builder().url(url).header("User-Agent", "Mozilla/5.0").build()
         client.newCall(request).execute().use { res ->
-            if (res.isSuccessful) res.body?.string() else null
+            if (res.isSuccessful) res.body.string() else null
         }
     }.getOrElse { Log.w(TAG, "Request failed: $url", it); null }
 
     internal fun downloadBytes(url: String): ByteArray? = runCatching {
         val request = Request.Builder().url(url).header("User-Agent", "Mozilla/5.0").build()
         client.newCall(request).execute().use { res ->
-            if (res.isSuccessful) res.body?.bytes() else null
+            if (res.isSuccessful) res.body.bytes() else null
         }
     }.getOrElse { Log.w(TAG, "Download failed: $url", it); null }
 

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicMetadataUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicMetadataUtil.kt
@@ -165,6 +165,16 @@ object MusicMetadataUtil {
         }
 
     /**
+     * The single best match for a video, tags and all.
+     *
+     * Used where there is no card to pick in: a download started before the video info landed
+     * still has to end up tagged, and by the time it finishes the naming it was started from
+     * is finally known. Only one candidate is fetched, since nobody is there to choose.
+     */
+    suspend fun resolveForVideo(videoTitle: String, uploader: String): MusicMetadata? =
+        searchFromVideo(videoTitle, uploader, limit = 1).firstOrNull()?.let { details(it) }
+
+    /**
      * Fills in the extended tags the search results left out. Runs for a single match, the one
      * on screen, so completing a result never costs more than the request the user waits for.
      */

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicMetadataUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicMetadataUtil.kt
@@ -1,0 +1,231 @@
+package com.deniscerri.ytdl.util.extractors.music
+
+import android.util.Log
+import com.deniscerri.ytdl.database.models.MusicMetadata
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.net.URLEncoder
+import java.util.concurrent.TimeUnit
+
+/**
+ * Resolves music tags (song, artist, album, year, genre, cover) for a video title
+ * by querying Deezer first and falling back to iTunes.
+ *
+ * The title parsing is heuristic: a video title like
+ * "Dhurata Dora ft. Soolking - Zemër (Official Video)" becomes
+ * artist="Dhurata Dora", title="Zemër", which is what the APIs expect.
+ */
+object MusicMetadataUtil {
+    private const val TAG = "MusicMetadataUtil"
+
+    // ── Title parsing ──────────────────────────────────────────────────────────
+
+    // Featuring inside the artist field: "Dhurata Dora ft. Soolking" → "Dhurata Dora"
+    private val FEAT_IN_ARTIST = Regex("""\s+(?:ft\.?|feat\.?|featuring)\s+.+$""", RegexOption.IGNORE_CASE)
+
+    // Featuring inside the title, both bracketed and bare (removed while cleaning)
+    private val FEAT_IN_TITLE = listOf(
+        Regex("""\s*[\(\[]\s*(?:ft\.?|feat\.?|featuring)\s+[^\)\]]+[\)\]]""", RegexOption.IGNORE_CASE),
+        Regex("""\s+(?:ft\.?|feat\.?|featuring)\s+.+$""", RegexOption.IGNORE_CASE),
+    )
+
+    private val FEAT_BRACKET = Regex("""[\(\[]\s*(?:ft\.?|feat\.?|featuring)\s+([^\)\]]+)[\)\]]""", RegexOption.IGNORE_CASE)
+    private val FEAT_BARE = Regex("""\s+(?:ft\.?|feat\.?|featuring)\s+(.+)$""", RegexOption.IGNORE_CASE)
+    private val HAS_FEAT = Regex("""(?:ft\.?|feat\.?|featuring)""", RegexOption.IGNORE_CASE)
+
+    // Bracketed noise commonly appended to video titles
+    private val BRACKET_NOISE = Regex(
+        """[\(\[]\s*(?:""" +
+                """official\s*(?:music\s*|lyric\s*)?(?:video|audio|mv)?|""" +
+                """lyrics?\s*(?:video)?|""" +
+                """audio|hd|hq|4k|uhd|""" +
+                """remaster(?:ed)?(?:\s+\d+)?|""" +
+                """visuali[sz]er|tiktok|""" +
+                """slowed(?:\s*[+&]\s*reverb)?|sped[\s-]*up|nightcore|""" +
+                """radio[\s-]*edit|""" +
+                """(?:piano|violin|guitar|acoustic|orchestral)\s*(?:version|cover|solo)?|""" +
+                """(?:\w[\w\s]*?\s+)?cover(?:\s+by\s+[^\)]+)?|""" +
+                """(?:\w[\w\s]*?\s+)?remix|""" +
+                """(?:album|single|extended|clean|explicit|radio)\s*(?:version|mix|edit)?|""" +
+                """non[\s-]?credits?(?:\s+(?:opening|ending|op|ed))?|""" +
+                """(?:opening|ending|op|ed)\s*\d*|""" +
+                """ost|version|edit|music\s+video""" +
+                """)\s*[\)\]]""",
+        RegexOption.IGNORE_CASE
+    )
+
+    private val ARTIST_SPLIT = Regex("""\s*,\s*|\s*&\s*|\s+[xX]\s+""")
+    private val TITLE_SPLIT = Regex("""\s*[-–—|]\s*""")
+    private val UNSAFE_FILENAME = Regex("""[\\/:*?"<>|]""")
+
+    private fun parseArtistField(raw: String): List<String> =
+        ARTIST_SPLIT.split(FEAT_IN_ARTIST.replace(raw, "").trim())
+            .map { it.trim() }.filter { it.isNotEmpty() }
+
+    private fun formatArtists(artists: List<String>): String = when {
+        artists.size >= 3 -> artists.first()                      // 3+ artists is too noisy to match
+        artists.size == 2 -> "${artists[0]} & ${artists[1]}"
+        else -> artists.firstOrNull().orEmpty()
+    }
+
+    /** Strips featuring info, bracketed noise and trailing descriptions from a video title. */
+    fun cleanTitle(raw: String): String {
+        var s = raw
+        FEAT_IN_TITLE.forEach { s = it.replace(s, "") }
+        s = BRACKET_NOISE.replace(s, "")
+        s = Regex("""\s*\|\s*.+$""").replace(s, "")     // trailing "| description"
+        s = Regex("""//\s*.+$""").replace(s, "")        // trailing "// description"
+        s = Regex("""\s{2,}""").replace(s, " ")
+        return s.trim().trimEnd('-', '|', ' ', ',')
+    }
+
+    /** Removes the " - Topic" suffix auto-generated channels carry. */
+    fun cleanUploader(raw: String): String =
+        raw.replace(Regex("""\s*-\s*Topic$""", RegexOption.IGNORE_CASE), "").trim()
+
+    /**
+     * Featuring artists mentioned in the title portion only, so that
+     * "Dhurata Dora ft. Soolking - Zemër" doesn't report Soolking (a main artist there).
+     */
+    fun extractFeaturing(rawVideoTitle: String): String? {
+        val parts = rawVideoTitle.split(Regex("""\s*[-–]\s*"""), limit = 2)
+        val searchIn = if (parts.size == 2) parts[1].trim() else rawVideoTitle
+
+        FEAT_BRACKET.find(searchIn)?.groupValues?.get(1)?.trim()?.trimEnd('.', ' ')?.ifBlank { null }
+            ?.let { return it }
+        FEAT_BARE.find(searchIn)?.groupValues?.get(1)?.trim()?.trimEnd('.', ' ')?.ifBlank { null }
+            ?.let { return it }
+        return null
+    }
+
+    /** Appends "(feat. X)" from the original video title if the API result dropped it. */
+    fun enrichWithFeaturing(metadata: MusicMetadata, rawVideoTitle: String): MusicMetadata {
+        if (HAS_FEAT.containsMatchIn(metadata.title)) return metadata
+        val feat = extractFeaturing(rawVideoTitle) ?: return metadata
+        return metadata.copy(title = "${metadata.title} (feat. $feat)")
+    }
+
+    /**
+     * Ordered (artist, title) candidates for a video title.
+     * The reversed candidate covers "Song - Artist1 & Artist2" style titles.
+     */
+    fun buildSearchQueries(rawTitle: String, uploader: String = ""): List<Pair<String, String>> {
+        val parts = rawTitle.split(TITLE_SPLIT, limit = 2)
+        if (parts.size != 2) {
+            // No separator: the uploader is the best artist guess (music channels, " - Topic")
+            return listOf(formatArtists(parseArtistField(cleanUploader(uploader))) to cleanTitle(rawTitle))
+        }
+
+        val left = parts[0].trim()
+        val right = parts[1].trim()
+        val queries = mutableListOf(formatArtists(parseArtistField(left)) to cleanTitle(right))
+
+        val leftHasSeparators = ARTIST_SPLIT.containsMatchIn(left)
+        val rightHasSeparators = ARTIST_SPLIT.containsMatchIn(right)
+        if (rightHasSeparators && !leftHasSeparators && !right.contains('(')) {
+            queries.add(formatArtists(parseArtistField(cleanTitle(right))) to cleanTitle(left))
+        }
+        return queries
+    }
+
+    /** Filesystem-safe "Artist - Title.ext". */
+    fun buildFileName(metadata: MusicMetadata, extension: String): String {
+        val name = UNSAFE_FILENAME.replace(metadata.displayName(), "_")
+            .replace(Regex("""\s{2,}"""), " ").trim()
+        return if (extension.isBlank()) name else "$name.$extension"
+    }
+
+    // ── Networking ─────────────────────────────────────────────────────────────
+
+    private val client by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(8, TimeUnit.SECONDS)
+            .readTimeout(8, TimeUnit.SECONDS)
+            .build()
+    }
+
+    internal fun httpGet(url: String): String? = runCatching {
+        val request = Request.Builder().url(url).header("User-Agent", "Mozilla/5.0").build()
+        client.newCall(request).execute().use { res ->
+            if (res.isSuccessful) res.body?.string() else null
+        }
+    }.getOrElse { Log.w(TAG, "Request failed: $url", it); null }
+
+    internal fun downloadBytes(url: String): ByteArray? = runCatching {
+        val request = Request.Builder().url(url).header("User-Agent", "Mozilla/5.0").build()
+        client.newCall(request).execute().use { res ->
+            if (res.isSuccessful) res.body?.bytes() else null
+        }
+    }.getOrElse { Log.w(TAG, "Download failed: $url", it); null }
+
+    private fun encode(value: String) = URLEncoder.encode(value, "UTF-8")
+
+    private fun JsonObject.str(key: String): String =
+        runCatching { get(key)?.takeIf { !it.isJsonNull }?.asString.orEmpty() }.getOrDefault("")
+
+    private fun JsonObject.obj(key: String): JsonObject? =
+        runCatching { getAsJsonObject(key) }.getOrNull()
+
+    // ── Providers ──────────────────────────────────────────────────────────────
+
+    private fun fetchFromDeezer(query: String, limit: Int): List<MusicMetadata> = runCatching {
+        val raw = httpGet("https://api.deezer.com/search?q=${encode(query)}&limit=$limit") ?: return emptyList()
+        JsonParser.parseString(raw).asJsonObject.getAsJsonArray("data").map { element ->
+            val track = element.asJsonObject
+            val album = track.obj("album")
+            MusicMetadata(
+                title = track.str("title"),
+                artist = track.obj("artist")?.str("name").orEmpty(),
+                album = album?.str("title").orEmpty(),
+                year = album?.str("release_date")?.take(4).orEmpty(),
+                coverUrl = album?.str("cover_xl").orEmpty()
+            )
+        }.filter { it.isUsable }
+    }.getOrElse { Log.w(TAG, "Deezer parsing failed", it); emptyList() }
+
+    private fun fetchFromItunes(query: String, limit: Int): List<MusicMetadata> = runCatching {
+        val raw = httpGet("https://itunes.apple.com/search?term=${encode(query)}&entity=song&limit=$limit")
+            ?: return emptyList()
+        JsonParser.parseString(raw).asJsonObject.getAsJsonArray("results").map { element ->
+            val track = element.asJsonObject
+            MusicMetadata(
+                title = track.str("trackName"),
+                artist = track.str("artistName"),
+                album = track.str("collectionName"),
+                year = track.str("releaseDate").take(4),
+                genre = track.str("primaryGenreName"),
+                coverUrl = track.str("artworkUrl100").replace("100x100bb", "1200x1200bb")
+            )
+        }.filter { it.isUsable }
+    }.getOrElse { Log.w(TAG, "iTunes parsing failed", it); emptyList() }
+
+    // ── Public API ─────────────────────────────────────────────────────────────
+
+    /** Explicit search, used by the manual "artist + song" lookup. */
+    suspend fun search(artist: String, title: String, limit: Int = MATCH_LIMIT): List<MusicMetadata> =
+        withContext(Dispatchers.IO) {
+            val query = listOf(artist, title).filter { it.isNotBlank() }.joinToString(" ")
+            if (query.isBlank()) return@withContext emptyList()
+            fetchFromDeezer(query, limit).ifEmpty { fetchFromItunes(query, limit) }
+        }
+
+    /**
+     * Automatic lookup from the fetched video info. Tries every parsed candidate and
+     * enriches the results with featuring artists mentioned in the original title.
+     */
+    suspend fun searchFromVideo(videoTitle: String, uploader: String, limit: Int = MATCH_LIMIT): List<MusicMetadata> =
+        withContext(Dispatchers.IO) {
+            buildSearchQueries(videoTitle, uploader)
+                .firstNotNullOfOrNull { (artist, title) ->
+                    search(artist, title, limit).ifEmpty { null }
+                }
+                ?.map { enrichWithFeaturing(it, videoTitle) }
+                ?: emptyList()
+        }
+
+    const val MATCH_LIMIT = 8
+}

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicMetadataUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicMetadataUtil.kt
@@ -1,26 +1,21 @@
 package com.deniscerri.ytdl.util.extractors.music
 
-import android.util.Log
 import com.deniscerri.ytdl.database.models.MusicMetadata
-import com.google.gson.JsonObject
-import com.google.gson.JsonParser
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import java.net.URLEncoder
-import java.util.concurrent.TimeUnit
 
 /**
- * Resolves music tags (song, artist, album, year, genre, cover) for a video title
- * by querying Deezer first and falling back to iTunes.
+ * Resolves music tags for a video title: turns it into something a catalogue can answer,
+ * then asks the [MusicProvider]s in turn.
  *
  * The title parsing is heuristic: a video title like
  * "Dhurata Dora ft. Soolking - Zemër (Official Video)" becomes
  * artist="Dhurata Dora", title="Zemër", which is what the APIs expect.
+ *
+ * This is the only place that decides where the lookup runs, so the providers themselves are
+ * free to block and to parallelise their own requests.
  */
 object MusicMetadataUtil {
-    private const val TAG = "MusicMetadataUtil"
 
     // ── Title parsing ──────────────────────────────────────────────────────────
 
@@ -139,78 +134,20 @@ object MusicMetadataUtil {
         return if (extension.isBlank()) name else "$name.$extension"
     }
 
-    // ── Networking ─────────────────────────────────────────────────────────────
+    // ── Lookup ─────────────────────────────────────────────────────────────
 
-    private val client by lazy {
-        OkHttpClient.Builder()
-            .connectTimeout(8, TimeUnit.SECONDS)
-            .readTimeout(8, TimeUnit.SECONDS)
-            .build()
-    }
-
-    internal fun httpGet(url: String): String? = runCatching {
-        val request = Request.Builder().url(url).header("User-Agent", "Mozilla/5.0").build()
-        client.newCall(request).execute().use { res ->
-            if (res.isSuccessful) res.body.string() else null
-        }
-    }.getOrElse { Log.w(TAG, "Request failed: $url", it); null }
-
-    internal fun downloadBytes(url: String): ByteArray? = runCatching {
-        val request = Request.Builder().url(url).header("User-Agent", "Mozilla/5.0").build()
-        client.newCall(request).execute().use { res ->
-            if (res.isSuccessful) res.body.bytes() else null
-        }
-    }.getOrElse { Log.w(TAG, "Download failed: $url", it); null }
-
-    private fun encode(value: String) = URLEncoder.encode(value, "UTF-8")
-
-    private fun JsonObject.str(key: String): String =
-        runCatching { get(key)?.takeIf { !it.isJsonNull }?.asString.orEmpty() }.getOrDefault("")
-
-    private fun JsonObject.obj(key: String): JsonObject? =
-        runCatching { getAsJsonObject(key) }.getOrNull()
-
-    // ── Providers ──────────────────────────────────────────────────────────────
-
-    private fun fetchFromDeezer(query: String, limit: Int): List<MusicMetadata> = runCatching {
-        val raw = httpGet("https://api.deezer.com/search?q=${encode(query)}&limit=$limit") ?: return emptyList()
-        JsonParser.parseString(raw).asJsonObject.getAsJsonArray("data").map { element ->
-            val track = element.asJsonObject
-            val album = track.obj("album")
-            MusicMetadata(
-                title = track.str("title"),
-                artist = track.obj("artist")?.str("name").orEmpty(),
-                album = album?.str("title").orEmpty(),
-                year = album?.str("release_date")?.take(4).orEmpty(),
-                coverUrl = album?.str("cover_xl").orEmpty()
-            )
-        }.filter { it.isUsable }
-    }.getOrElse { Log.w(TAG, "Deezer parsing failed", it); emptyList() }
-
-    private fun fetchFromItunes(query: String, limit: Int): List<MusicMetadata> = runCatching {
-        val raw = httpGet("https://itunes.apple.com/search?term=${encode(query)}&entity=song&limit=$limit")
-            ?: return emptyList()
-        JsonParser.parseString(raw).asJsonObject.getAsJsonArray("results").map { element ->
-            val track = element.asJsonObject
-            MusicMetadata(
-                title = track.str("trackName"),
-                artist = track.str("artistName"),
-                album = track.str("collectionName"),
-                year = track.str("releaseDate").take(4),
-                genre = track.str("primaryGenreName"),
-                coverUrl = track.str("artworkUrl100").replace("100x100bb", "1200x1200bb")
-            )
-        }.filter { it.isUsable }
-    }.getOrElse { Log.w(TAG, "iTunes parsing failed", it); emptyList() }
-
-    // ── Public API ─────────────────────────────────────────────────────────────
+    /**
+     * The catalogues, in the order they are consulted: the first one with a hit answers the
+     * lookup. Adding one is adding it here.
+     */
+    private val providers = listOf(DeezerProvider, ItunesProvider)
 
     /** Explicit search, used by the manual "artist + song" lookup. */
     suspend fun search(artist: String, title: String, limit: Int = MATCH_LIMIT): List<MusicMetadata> =
         withContext(Dispatchers.IO) {
             val query = listOf(artist, title).filter { it.isNotBlank() }.joinToString(" ")
             if (query.isBlank()) return@withContext emptyList()
-            fetchFromDeezer(query, limit).ifEmpty { fetchFromItunes(query, limit) }
+            providers.firstNotNullOfOrNull { it.search(query, limit).ifEmpty { null } }.orEmpty()
         }
 
     /**
@@ -224,8 +161,17 @@ object MusicMetadataUtil {
                     search(artist, title, limit).ifEmpty { null }
                 }
                 ?.map { enrichWithFeaturing(it, videoTitle) }
-                ?: emptyList()
+                .orEmpty()
         }
+
+    /**
+     * Fills in the extended tags the search results left out. Runs for a single match, the one
+     * on screen, so completing a result never costs more than the request the user waits for.
+     */
+    suspend fun details(metadata: MusicMetadata): MusicMetadata = withContext(Dispatchers.IO) {
+        val provider = providers.firstOrNull { it.id == metadata.source?.provider }
+        provider?.details(metadata) ?: metadata
+    }
 
     const val MATCH_LIMIT = 8
 }

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicProvider.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicProvider.kt
@@ -1,0 +1,49 @@
+package com.deniscerri.ytdl.util.extractors.music
+
+import com.deniscerri.ytdl.database.models.MusicMetadata
+import com.deniscerri.ytdl.database.models.MusicSource
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+
+/**
+ * A catalogue the song tags can be resolved from.
+ *
+ * The contract is split in two on purpose. [search] stays cheap, one request that returns the
+ * candidates the picker needs, so a lookup never costs more than the user can see. The tags a
+ * catalogue only exposes on its detail endpoints are left to [details], which runs for the one
+ * candidate the card actually shows instead of the whole result list.
+ *
+ * Both are suspending because they hit the network, and both may block: they are always called
+ * from [MusicMetadataUtil] on a background dispatcher.
+ */
+interface MusicProvider {
+
+    /** Matches [MusicSource.provider], so a result finds its own catalogue again later. */
+    val id: String
+
+    suspend fun search(query: String, limit: Int): List<MusicMetadata>
+
+    /**
+     * Completes [metadata] with the fields [search] could not carry. Catalogues that already
+     * return everything leave this alone.
+     */
+    suspend fun details(metadata: MusicMetadata): MusicMetadata = metadata
+}
+
+// ── JSON reading shared by the providers ───────────────────────────────────────
+//
+// The APIs are loosely typed and occasionally omit or null out fields, so every read degrades
+// to an empty value rather than throwing: a missing tag is simply one that stays blank.
+
+internal fun JsonObject.str(key: String): String =
+    runCatching { get(key)?.takeIf { !it.isJsonNull }?.asString.orEmpty() }.getOrDefault("")
+
+internal fun JsonObject.obj(key: String): JsonObject? =
+    runCatching { getAsJsonObject(key) }.getOrNull()
+
+internal fun JsonObject.arr(key: String): JsonArray =
+    runCatching { getAsJsonArray(key) }.getOrNull() ?: JsonArray()
+
+/** The first value a catalogue actually filled in, used to fall back between equivalent fields. */
+internal fun firstNonBlank(vararg values: String?): String =
+    values.firstOrNull { !it.isNullOrBlank() }.orEmpty()

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicProvider.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/music/MusicProvider.kt
@@ -21,6 +21,9 @@ interface MusicProvider {
     /** Matches [MusicSource.provider], so a result finds its own catalogue again later. */
     val id: String
 
+    /** Brand name, shown when the manual search lets the user aim at one catalogue. */
+    val name: String
+
     suspend fun search(query: String, limit: Int): List<MusicMetadata>
 
     /**

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/ytdlp/YTDLPUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/ytdlp/YTDLPUtil.kt
@@ -1229,7 +1229,9 @@ class YTDLPUtil(private val context: Context, private val commandTemplateDao: Co
                     }
 
                     val cropThumb = downloadItem.audioPreferences.cropThumb ?: sharedPreferences.getBoolean("crop_thumbnail", true)
-                    if (downloadItem.audioPreferences.embedThumb){
+                    //music mode embeds the fetched album cover afterwards, so skip the video thumbnail
+                    val hasMusicCover = downloadItem.audioPreferences.musicMetadata?.coverUrl?.isNotBlank() == true
+                    if (downloadItem.audioPreferences.embedThumb && !hasMusicCover){
                         metadataCommands.addOption("--embed-thumbnail")
                         if (!request.toString().contains("--convert-thumbnails")) metadataCommands.addOption("--convert-thumbnails", thumbnailFormat!!)
 

--- a/app/src/main/java/com/deniscerri/ytdl/work/download/DownloadWorker.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/work/download/DownloadWorker.kt
@@ -24,6 +24,7 @@ import com.deniscerri.ytdl.MainActivity
 import com.deniscerri.ytdl.R
 import com.deniscerri.ytdl.core.RuntimeManager
 import com.deniscerri.ytdl.database.DBManager
+import com.deniscerri.ytdl.database.enums.DownloadType
 import com.deniscerri.ytdl.database.models.HistoryItem
 import com.deniscerri.ytdl.database.models.LogItem
 import com.deniscerri.ytdl.database.repository.DownloadRepository
@@ -33,6 +34,7 @@ import com.deniscerri.ytdl.util.AlarmScheduler
 import com.deniscerri.ytdl.util.Extensions.getMediaDuration
 import com.deniscerri.ytdl.util.Extensions.toStringDuration
 import com.deniscerri.ytdl.util.FileUtil
+import com.deniscerri.ytdl.util.MusicTagUtil
 import com.deniscerri.ytdl.util.NotificationUtil
 import com.deniscerri.ytdl.util.WorkerEventBus
 import com.deniscerri.ytdl.util.extractors.ytdlp.YTDLPUtil
@@ -254,6 +256,10 @@ class DownloadWorker(
                         runBlocking {
                             var finalPaths = mutableListOf<String>()
 
+                            //music mode: tags and renames the finished audio to "Artist - Title"
+                            val musicMetadata = downloadItem.audioPreferences.musicMetadata
+                                ?.takeIf { downloadItem.type == DownloadType.audio && it.isUsable }
+
                             if (noCache){
                                 WorkerEventBus.post(WorkerProgress(100, "Scanning Files", downloadItem.id, downloadItem.logID))
                                 val outputSequence = it.out.split("\n")
@@ -274,8 +280,13 @@ class DownloadWorker(
 
                                 finalPaths.sortBy { File(it).lastModified() }
                                 finalPaths = finalPaths.distinct().toMutableList()
+                                musicMetadata?.let {
+                                    finalPaths = MusicTagUtil.applyToPaths(finalPaths, it).toMutableList()
+                                }
                                 FileUtil.scanMedia(finalPaths, context)
                             }else{
+                                musicMetadata?.let { MusicTagUtil.applyToDirectory(tempFileDir, it) }
+
                                 //move file from internal to set download directory
                                 WorkerEventBus.post(WorkerProgress(100, "Moving file to ${FileUtil.formatPath(downloadLocation)}", downloadItem.id, downloadItem.logID))
                                 try {

--- a/app/src/main/java/com/deniscerri/ytdl/work/download/DownloadWorker.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/work/download/DownloadWorker.kt
@@ -25,8 +25,10 @@ import com.deniscerri.ytdl.R
 import com.deniscerri.ytdl.core.RuntimeManager
 import com.deniscerri.ytdl.database.DBManager
 import com.deniscerri.ytdl.database.enums.DownloadType
+import com.deniscerri.ytdl.database.models.DownloadItem
 import com.deniscerri.ytdl.database.models.HistoryItem
 import com.deniscerri.ytdl.database.models.LogItem
+import com.deniscerri.ytdl.database.models.MusicMetadata
 import com.deniscerri.ytdl.database.repository.DownloadRepository
 import com.deniscerri.ytdl.database.repository.LogRepository
 import com.deniscerri.ytdl.database.repository.ResultRepository
@@ -37,6 +39,7 @@ import com.deniscerri.ytdl.util.FileUtil
 import com.deniscerri.ytdl.util.MusicTagUtil
 import com.deniscerri.ytdl.util.NotificationUtil
 import com.deniscerri.ytdl.util.WorkerEventBus
+import com.deniscerri.ytdl.util.extractors.music.MusicMetadataUtil
 import com.deniscerri.ytdl.util.extractors.ytdlp.YTDLPUtil
 import com.deniscerri.ytdl.work.isRunning
 import com.deniscerri.ytdl.work.setForegroundSafely
@@ -257,8 +260,7 @@ class DownloadWorker(
                             var finalPaths = mutableListOf<String>()
 
                             //music mode: tags and renames the finished audio to "Artist - Title"
-                            val musicMetadata = downloadItem.audioPreferences.musicMetadata
-                                ?.takeIf { downloadItem.type == DownloadType.audio && it.isUsable }
+                            val musicMetadata = resolveMusicTags(downloadItem)
 
                             if (noCache){
                                 WorkerEventBus.post(WorkerProgress(100, "Scanning Files", downloadItem.id, downloadItem.logID))
@@ -444,7 +446,20 @@ class DownloadWorker(
         return Result.success()
     }
 
-
+    /**
+     * The song tags to write into the finished audio, or null when this is not a music download.
+     *
+     * The card normally resolves them while the user is still looking at it, but a download can
+     * be started before the video info it looks up is even fetched. That is the quick path: the
+     * user trusts the video naming, so the lookup that could not run back then runs here, where
+     * the naming is finally known.
+     */
+    private suspend fun resolveMusicTags(item: DownloadItem): MusicMetadata? {
+        if (item.type != DownloadType.audio) return null
+        item.audioPreferences.musicMetadata?.takeIf { it.isUsable }?.let { return it }
+        if (!item.audioPreferences.musicMode) return null
+        return MusicMetadataUtil.resolveForVideo(item.title, item.author)
+    }
 
     companion object {
         val runningYTDLInstances: MutableList<Long> = mutableListOf()

--- a/app/src/main/res/layout/dialog_music_search.xml
+++ b/app/src/main/res/layout/dialog_music_search.xml
@@ -38,4 +38,20 @@
 
     </com.google.android.material.textfield.TextInputLayout>
 
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/music_search_provider"
+        style="@style/Widget.Material3.TextInputLayout.FilledBox.ExposedDropdownMenu"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="@string/source">
+
+        <com.google.android.material.textfield.MaterialAutoCompleteTextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="none"
+            android:maxLines="1" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_music_search.xml
+++ b/app/src/main/res/layout/dialog_music_search.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="24dp"
+    android:paddingTop="10dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/music_search_artist"
+        style="@style/Widget.Material3.TextInputLayout.FilledBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/artist">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text"
+            android:maxLines="1" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/music_search_song"
+        style="@style/Widget.Material3.TextInputLayout.FilledBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="@string/song">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:imeOptions="actionSearch"
+            android:inputType="text"
+            android:maxLines="1" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_download_audio.xml
+++ b/app/src/main/res/layout/fragment_download_audio.xml
@@ -13,6 +13,8 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
+            <include layout="@layout/music_metadata_card" />
+
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/title_textinput"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/music_metadata_card.xml
+++ b/app/src/main/res/layout/music_metadata_card.xml
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/music_card"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="10dp"
+    android:paddingTop="10dp">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/music_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clickable="true"
+        android:focusable="true"
+        app:cardElevation="0dp"
+        app:shapeAppearance="@style/ShapeAppearanceOverlay.Avatar2"
+        app:strokeWidth="0dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingHorizontal="14dp"
+            android:paddingVertical="10dp">
+
+            <ImageView
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:contentDescription="@string/music_mode"
+                android:src="@drawable/ic_music"
+                app:tint="?attr/colorPrimary" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="14dp"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/music_mode"
+                    android:textAppearance="@style/TextAppearance.Material3.TitleSmall" />
+
+                <TextView
+                    android:id="@+id/music_status"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:maxLines="2"
+                    android:ellipsize="end"
+                    android:text="@string/music_mode_summary"
+                    android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                    android:textColor="@android:color/tab_indicator_text" />
+
+            </LinearLayout>
+
+            <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/music_progress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="10dp"
+                android:indeterminate="true"
+                android:visibility="gone"
+                app:indicatorSize="20dp"
+                app:trackThickness="2dp" />
+
+            <com.google.android.material.materialswitch.MaterialSwitch
+                android:id="@+id/music_switch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="false"
+                android:focusable="false" />
+
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
+    <LinearLayout
+        android:id="@+id/music_content"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <com.google.android.material.imageview.ShapeableImageView
+                android:id="@+id/music_cover"
+                android:layout_width="100dp"
+                android:layout_height="100dp"
+                android:background="?attr/colorSurfaceVariant"
+                android:contentDescription="@string/cover_art"
+                android:padding="0dp"
+                android:scaleType="centerCrop"
+                android:src="@drawable/ic_music"
+                app:shapeAppearance="@style/ShapeAppearanceOverlay.Avatar2" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/music_song_textinput"
+                    style="@style/Widget.Material3.TextInputLayout.FilledBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/song">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="text"
+                        android:maxLines="1" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/music_artist_textinput"
+                    style="@style/Widget.Material3.TextInputLayout.FilledBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:hint="@string/artist">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="text"
+                        android:maxLines="1" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:divider="@drawable/divider_10dp"
+            android:orientation="horizontal"
+            android:showDividers="middle">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/music_album_textinput"
+                style="@style/Widget.Material3.TextInputLayout.FilledBox"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="60"
+                android:hint="@string/album">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="text"
+                    android:maxLines="1" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/music_year_textinput"
+                style="@style/Widget.Material3.TextInputLayout.FilledBox"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="40"
+                android:hint="@string/year">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="number"
+                    android:maxLength="4"
+                    android:maxLines="1" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+        </LinearLayout>
+
+        <HorizontalScrollView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:scrollbars="none">
+
+            <com.google.android.material.chip.ChipGroup
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:chipSpacingVertical="0dp"
+                app:singleLine="true">
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/music_matches"
+                    style="@style/Widget.Material3.Chip.Assist.Elevated"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:outlineProvider="none"
+                    android:text="@string/other_matches"
+                    app:chipIcon="@drawable/ic_music"
+                    app:chipIconVisible="true" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/music_manual_search"
+                    style="@style/Widget.Material3.Chip.Assist.Elevated"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:outlineProvider="none"
+                    android:text="@string/search_song"
+                    app:chipIcon="@drawable/ic_search"
+                    app:chipIconVisible="true" />
+
+            </com.google.android.material.chip.ChipGroup>
+
+        </HorizontalScrollView>
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/music_metadata_card.xml
+++ b/app/src/main/res/layout/music_metadata_card.xml
@@ -92,16 +92,25 @@
             android:layout_height="wrap_content"
             android:orientation="horizontal">
 
-            <com.google.android.material.imageview.ShapeableImageView
-                android:id="@+id/music_cover"
+            <!-- Sweeps the artwork while the song is being looked up, so the card reads as
+                 working rather than as an empty cover the user has to interpret -->
+            <com.facebook.shimmer.ShimmerFrameLayout
+                android:id="@+id/music_cover_shimmer"
                 android:layout_width="100dp"
-                android:layout_height="100dp"
-                android:background="?attr/colorSurfaceVariant"
-                android:contentDescription="@string/cover_art"
-                android:padding="0dp"
-                android:scaleType="centerCrop"
-                android:src="@drawable/ic_music"
-                app:shapeAppearance="@style/ShapeAppearanceOverlay.Avatar2" />
+                android:layout_height="100dp">
+
+                <com.google.android.material.imageview.ShapeableImageView
+                    android:id="@+id/music_cover"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="?attr/colorSurfaceVariant"
+                    android:contentDescription="@string/cover_art"
+                    android:padding="0dp"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/ic_music"
+                    app:shapeAppearance="@style/ShapeAppearanceOverlay.Avatar2" />
+
+            </com.facebook.shimmer.ShimmerFrameLayout>
 
             <LinearLayout
                 android:layout_width="0dp"

--- a/app/src/main/res/layout/music_metadata_card.xml
+++ b/app/src/main/res/layout/music_metadata_card.xml
@@ -219,9 +219,160 @@
                     app:chipIcon="@drawable/ic_search"
                     app:chipIconVisible="true" />
 
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/music_details"
+                    style="@style/Widget.Material3.Chip.Assist.Elevated"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:outlineProvider="none"
+                    android:text="@string/more_details"
+                    app:chipIcon="@drawable/baseline_expand_more_24"
+                    app:chipIconVisible="true" />
+
             </com.google.android.material.chip.ChipGroup>
 
         </HorizontalScrollView>
+
+        <!-- The tags the catalogues resolve on top of the song itself, folded away until asked -->
+        <LinearLayout
+            android:id="@+id/music_extra"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/music_album_artist_textinput"
+                style="@style/Widget.Material3.TextInputLayout.FilledBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/album_artist">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="text"
+                    android:maxLines="1" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:divider="@drawable/divider_10dp"
+                android:orientation="horizontal"
+                android:showDividers="middle">
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/music_genre_textinput"
+                    style="@style/Widget.Material3.TextInputLayout.FilledBox"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="50"
+                    android:hint="@string/genre">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="text"
+                        android:maxLines="1" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/music_label_textinput"
+                    style="@style/Widget.Material3.TextInputLayout.FilledBox"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="50"
+                    android:hint="@string/record_label">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="text"
+                        android:maxLines="1" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:divider="@drawable/divider_10dp"
+                android:orientation="horizontal"
+                android:showDividers="middle">
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/music_track_textinput"
+                    style="@style/Widget.Material3.TextInputLayout.FilledBox"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:hint="@string/track_number">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="number"
+                        android:maxLines="1" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/music_track_total_textinput"
+                    style="@style/Widget.Material3.TextInputLayout.FilledBox"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:hint="@string/track_total">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="number"
+                        android:maxLines="1" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/music_disc_textinput"
+                    style="@style/Widget.Material3.TextInputLayout.FilledBox"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:hint="@string/disc_number">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="number"
+                        android:maxLines="1" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+            </LinearLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/music_isrc_textinput"
+                style="@style/Widget.Material3.TextInputLayout.FilledBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:hint="@string/isrc">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textCapCharacters"
+                    android:maxLines="1" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+        </LinearLayout>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/sheet_music_cover.xml
+++ b/app/src/main/res/layout/sheet_music_cover.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="24dp"
+    android:paddingTop="20dp"
+    android:paddingBottom="24dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/cover_art"
+        android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+
+    <!-- The shimmer sweeps the preview itself, so reading a cover looks like the image
+         settling in rather than a separate placeholder being swapped out -->
+    <com.facebook.shimmer.ShimmerFrameLayout
+        android:id="@+id/cover_shimmer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp">
+
+        <!-- Sizes itself to whatever it is showing: adjustViewBounds turns the image aspect into
+             the view height, bounded so neither a tiny nor a tall cover takes over the sheet -->
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/cover_preview"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:adjustViewBounds="true"
+            android:background="?attr/colorSurfaceVariant"
+            android:contentDescription="@string/cover_art"
+            android:maxHeight="360dp"
+            android:minHeight="200dp"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_music"
+            app:shapeAppearance="@style/ShapeAppearanceOverlay.Avatar2" />
+
+    </com.facebook.shimmer.ShimmerFrameLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:divider="@drawable/divider_10dp"
+        android:orientation="horizontal"
+        android:showDividers="middle">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/cover_choose"
+            style="@style/Widget.Material3.Button.TonalButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/choose_image" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/cover_confirm"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:enabled="false"
+            android:text="@string/use_this_cover" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -569,6 +569,7 @@
     <string name="music_mode">Download as music</string>
     <string name="music_mode_summary">Tag the file with the real song info</string>
     <string name="searching_song">Looking up song info…</string>
+    <string name="waiting_for_video_info">Waiting for video info…</string>
     <string name="song_not_found">No song found. Edit the fields or search manually</string>
     <string name="song">Song</string>
     <string name="artist">Artist</string>
@@ -577,4 +578,13 @@
     <string name="cover_art">Cover art</string>
     <string name="other_matches">Other matches</string>
     <string name="search_song">Search song</string>
+    <string name="more_details">More details</string>
+    <string name="fewer_details">Fewer details</string>
+    <string name="album_artist">Album artist</string>
+    <string name="genre">Genre</string>
+    <string name="record_label">Label</string>
+    <string name="track_number">Track</string>
+    <string name="track_total">Total</string>
+    <string name="disc_number">Disc</string>
+    <string name="isrc">ISRC</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -564,4 +564,17 @@
     <plurals name="every_days"><item quantity="one">Every day</item><item quantity="other">Every %d days</item></plurals>
     <plurals name="every_weeks"><item quantity="one">Every week</item><item quantity="other">Every %d weeks</item></plurals>
     <plurals name="every_months"><item quantity="one">Every month</item><item quantity="other">Every %d months</item></plurals>
+
+    <!-- Music metadata -->
+    <string name="music_mode">Download as music</string>
+    <string name="music_mode_summary">Tag the file with the real song info</string>
+    <string name="searching_song">Looking up song info…</string>
+    <string name="song_not_found">No song found. Edit the fields or search manually</string>
+    <string name="song">Song</string>
+    <string name="artist">Artist</string>
+    <string name="album">Album</string>
+    <string name="year">Year</string>
+    <string name="cover_art">Cover art</string>
+    <string name="other_matches">Other matches</string>
+    <string name="search_song">Search song</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -588,4 +588,6 @@
     <string name="disc_number">Disc</string>
     <string name="isrc">ISRC</string>
     <string name="all_sources">All sources</string>
+    <string name="choose_image">Choose image</string>
+    <string name="use_this_cover">Use this cover</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -587,4 +587,5 @@
     <string name="track_total">Total</string>
     <string name="disc_number">Disc</string>
     <string name="isrc">ISRC</string>
+    <string name="all_sources">All sources</string>
 </resources>

--- a/app/src/main/res/xml/downloading_preferences.xml
+++ b/app/src/main/res/xml/downloading_preferences.xml
@@ -91,11 +91,6 @@
             app:summary="@string/remember_download_type_summary"
             app:title="@string/remember_download_type" />
 
-        <Preference
-            android:defaultValue="video"
-            android:key="last_used_download_type"
-            app:isPreferenceVisible="false" />
-
         <SeekBarPreference
             android:defaultValue="3"
             android:icon="@drawable/ic_lines"


### PR DESCRIPTION
## What this adds

A **music mode** for audio downloads. When it's on, the song is looked up in online music catalogues (iTunes and Deezer) and the result is written into the downloaded file's tags: title, artist, album, year, cover art, plus the extended fields the catalogues expose (album artist, label, track and disc numbers, ISRC).

yt-dlp writes what the site gives it, which for music is usually the uploader as the artist and the video title as the track name. This resolves the real metadata at download time instead of leaving it to be fixed by hand afterwards.

The match is shown in the download card so it can be checked before downloading, and corrected:

- search again, optionally narrowed to a single catalogue
- pick a different match from the results
- edit any field by hand
- tap the cover to replace it with an image from the device

Anything the user changes or picks pins the result, so the automatic re-lookup that runs once the real video info arrives never overwrites an edit. Downloads that never went through the card (quick downloads) resolve their tags in the worker instead, taking the single best match, since there's nobody there to choose.

Catalogues sit behind a `MusicProvider` interface with the shared HTTP/JSON handling in `MusicHttp`, so adding a source is adding it to one list. Tags are written defensively: a blank field never wipes what the downloader wrote, and a key the container can't store is skipped rather than failing the whole write.

## Also included

Two download-card fixes that this sits on top of:

- **`fix(download): keep the card on the last used settings`** — the last used configuration was seeded into the card and then overwritten before the user saw it, so every download opened on the app defaults. The audio tab reset the container and re-picked the format from scratch once formats landed (the video tab already accounted for this); and the last used download type was written whenever a card was merely opened and on every tab swipe, so peeking at a tab counted as using it. The snapshot is now the single owner of the last used type, written only when a download is actually committed.
- **`fix(music): drop the null checks on the OkHttp response body`** — `body` is non-null in the OkHttp version already in use.

## Notes

- Music mode is a per-download setting on the download item, alongside the other card choices, not a global preference.
- Extended tags are fetched in a second request for the shown match only, after it's displayed, so completing a result never delays the one the user is already reading. They're folded away in the card until expanded.
- One new dependency: `net.jthink:jaudiotagger:3.0.1`, for writing the tags into the audio container. It's LGPL 2.1 — flagging it in case that matters for the project's licensing. The lookups reuse the OkHttp and Gson already in the project.

Built and tested locally on device. Commits are kept separate and each one stands on its own, so anything here can be dropped or reworked — happy to split this up or file an issue first if you'd rather discuss the approach before reviewing.
