### PR TITLE
network security config fixes to allow bgutils to work v2

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <!-- Keep HTTPS mandatory for standard network traffic -->
-    <base-config cleartextTrafficPermitted="false" />
-
+    <base-config
+        cleartextTrafficPermitted="false">
+    
     <!-- Grant cleartext HTTP permission ONLY for local server loopbacks -->
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">127.0.0.1</domain>
-        <domain includeSubdomains="true">localhost</domain>
+    <domain-config
+        cleartextTrafficPermitted="true">
+        <domain
+            includeSubdomains="true">127.0.0.1</domain>
+        <domain
+            includeSubdomains="true">localhost</domain>
     </domain-config>
+    </base-config>
 </network-security-config>


### PR DESCRIPTION
this fix came after decompiling the app then looked at the existing network security config and then i saw that there's `<base-config` without the closing `</base-config>`