### PR TITLE
allow ipv6 localhost 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 [![IzzyOnDroid repository](https://custom-icon-badges.herokuapp.com/badge/IzzyOnDroid%20Repo-red?style=for-the-badge&logo=download&logoColor=white)](https://apt.izzysoft.de/packages/com.deniscerri.ytdl)
 [![Uptodown](https://custom-icon-badges.herokuapp.com/badge/UpToDown-green?style=for-the-badge&logo=download&logoColor=white)](https://ytdlnis.en.uptodown.com/android/download)
 
-![CI](https://github.com/error-reporting/ytdlnis/blob/main/.github/workflows/android.yml/badge.svg?branch=main&event=pull)
+![CI](https://github.com/error-reporting/ytdlnis/actions/workflows/android.yml/badge.svg?branch=main&event=pull)
 [![Preview release](https://img.shields.io/github/release/deniscerri/ytdlnis.svg?maxAge=3600&include_prereleases&label=preview)](https://github.com/deniscerri/ytdlnis/releases) 
 [![Downloads](https://img.shields.io/github/downloads/deniscerri/ytdlnis/total?style=flat-square)](https://github.com/deniscerri/ytdlnis/releases) 
 [![Translation status](https://hosted.weblate.org/widgets/ytdlnis/-/svg-badge.svg)](https://hosted.weblate.org/engage/ytdlnis/?utm_source=widget) 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 [![IzzyOnDroid repository](https://custom-icon-badges.herokuapp.com/badge/IzzyOnDroid%20Repo-red?style=for-the-badge&logo=download&logoColor=white)](https://apt.izzysoft.de/packages/com.deniscerri.ytdl)
 [![Uptodown](https://custom-icon-badges.herokuapp.com/badge/UpToDown-green?style=for-the-badge&logo=download&logoColor=white)](https://ytdlnis.en.uptodown.com/android/download)
 
-![CI](https://github.com/deniscerri/ytdlnis/actions/workflows/android.yml/badge.svg?branch=main&event=pull)
+![CI](https://github.com/error-reporting/ytdlnis/blob/main/.github/workflows/android.yml/badge.svg?branch=main&event=pull)
 [![Preview release](https://img.shields.io/github/release/deniscerri/ytdlnis.svg?maxAge=3600&include_prereleases&label=preview)](https://github.com/deniscerri/ytdlnis/releases) 
 [![Downloads](https://img.shields.io/github/downloads/deniscerri/ytdlnis/total?style=flat-square)](https://github.com/deniscerri/ytdlnis/releases) 
 [![Translation status](https://hosted.weblate.org/widgets/ytdlnis/-/svg-badge.svg)](https://hosted.weblate.org/engage/ytdlnis/?utm_source=widget) 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 [![IzzyOnDroid repository](https://custom-icon-badges.herokuapp.com/badge/IzzyOnDroid%20Repo-red?style=for-the-badge&logo=download&logoColor=white)](https://apt.izzysoft.de/packages/com.deniscerri.ytdl)
 [![Uptodown](https://custom-icon-badges.herokuapp.com/badge/UpToDown-green?style=for-the-badge&logo=download&logoColor=white)](https://ytdlnis.en.uptodown.com/android/download)
 
-![CI](https://github.com/error-reporting/ytdlnis/actions/workflows/android.yml/badge.svg?branch=main&event=pull)
+![CI](https://github.com/deniscerri/ytdlnis/actions/workflows/android.yml/badge.svg?branch=main&event=pull)
 [![Preview release](https://img.shields.io/github/release/deniscerri/ytdlnis.svg?maxAge=3600&include_prereleases&label=preview)](https://github.com/deniscerri/ytdlnis/releases) 
 [![Downloads](https://img.shields.io/github/downloads/deniscerri/ytdlnis/total?style=flat-square)](https://github.com/deniscerri/ytdlnis/releases) 
 [![Translation status](https://hosted.weblate.org/widgets/ytdlnis/-/svg-badge.svg)](https://hosted.weblate.org/engage/ytdlnis/?utm_source=widget) 

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -7,6 +7,8 @@
     <!-- Grant cleartext HTTP permission ONLY for local server loopbacks -->
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">127.0.0.1</domain>
+        <domain includeSubdomains="true">[::1]</domain>
         <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="true">ip6-localhost</domain>
     </domain-config>
 </network-security-config>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -7,7 +7,7 @@
     <!-- Grant cleartext HTTP permission ONLY for local server loopbacks -->
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">127.0.0.1</domain>
-        <domain includeSubdomains="true">[::1]</domain>
+        <domain includeSubdomains="true">::1</domain>
         <domain includeSubdomains="true">localhost</domain>
         <domain includeSubdomains="true">ip6-localhost</domain>
     </domain-config>


### PR DESCRIPTION
this pull request allows ip6-localhost and ::1 in the network security configs as bgutil-ytdlp-pot-provider also supports connecting to it through ipv6 like this --extractor-args "youtubepot-bgutilhttp:base_url=http://[::1]:4416"