### PR TITLE
feat: resume downloads after connectivity loss

### DIFF
--- a/app/src/main/java/com/deniscerri/ytdl/MainActivity.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/MainActivity.kt
@@ -34,8 +34,10 @@ import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.FragmentContainerView
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
@@ -61,6 +63,7 @@ import com.deniscerri.ytdl.ui.more.settings.SettingsActivity
 import com.deniscerri.ytdl.util.CrashListener
 import com.deniscerri.ytdl.util.NavbarUtil
 import com.deniscerri.ytdl.util.NavbarUtil.applyNavBarStyle
+import com.deniscerri.ytdl.util.SubtitleRecoveryCoordinator
 import com.deniscerri.ytdl.util.ThemeUtil
 import com.deniscerri.ytdl.util.UiUtil
 import com.deniscerri.ytdl.util.UpdateUtil
@@ -109,6 +112,8 @@ class MainActivity : BaseActivity() {
     private lateinit var navHostFragment : NavHostFragment
     private lateinit var navController : NavController
     private var loadingRuntimeDialog: androidx.appcompat.app.AlertDialog? = null
+    private var subtitleRecoveryDialog: AlertDialog? = null
+    private var shownSubtitleRecoveryRequestId: Long? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -285,12 +290,62 @@ class MainActivity : BaseActivity() {
             getHeaderView(0).findViewById<TextView>(R.id.title).text = ThemeUtil.getStyledAppName(this@MainActivity)
         }
 
+        observeSubtitleRecoveryRequests()
         cookieViewModel.updateCookiesFile()
         val intent = intent
         handleIntents(intent)
 
         askAutoUpdatePreferences()
     }
+
+    /** Presents subtitle recovery after the user returns to the foreground. */
+    private fun observeSubtitleRecoveryRequests() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                SubtitleRecoveryCoordinator.requests.collectLatest { requests ->
+                    val request = requests.firstOrNull()
+                    if (request == null) {
+                        subtitleRecoveryDialog?.dismiss()
+                        subtitleRecoveryDialog = null
+                        shownSubtitleRecoveryRequestId = null
+                    } else if (shownSubtitleRecoveryRequestId != request.requestId) {
+                        showSubtitleRecoveryDialog(request)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun showSubtitleRecoveryDialog(request: SubtitleRecoveryCoordinator.Request) {
+        subtitleRecoveryDialog?.dismiss()
+        shownSubtitleRecoveryRequestId = request.requestId
+
+        subtitleRecoveryDialog = MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.subtitle_download_failed)
+            .setMessage(request.message)
+            .setCancelable(false)
+            .setPositiveButton(R.string.continue_download) { _, _ ->
+                SubtitleRecoveryCoordinator.resolve(
+                    request.requestId,
+                    SubtitleRecoveryCoordinator.Action.CONTINUE,
+                )
+            }
+            .setNeutralButton(R.string.retry) { _, _ ->
+                SubtitleRecoveryCoordinator.resolve(
+                    request.requestId,
+                    SubtitleRecoveryCoordinator.Action.RETRY,
+                )
+            }
+            .setNegativeButton(R.string.cancel) { _, _ ->
+                SubtitleRecoveryCoordinator.resolve(
+                    request.requestId,
+                    SubtitleRecoveryCoordinator.Action.CANCEL,
+                )
+            }
+            .create()
+            .also { it.show() }
+    }
+
     override fun onSaveInstanceState(savedInstanceState: Bundle) {
         super.onSaveInstanceState(savedInstanceState)
         savedInstanceState.putBundle("nav_state", navController.saveState())

--- a/app/src/main/java/com/deniscerri/ytdl/core/RuntimeManager.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/core/RuntimeManager.kt
@@ -253,34 +253,47 @@ object RuntimeManager {
         assertInit()
         assertNoUpdate()
 
-        if (ffmpegLocation.isAvailable) {
+        // Worker-level retries reuse the same request. Add runtime-owned options only
+        // once so each attempt executes an equivalent command.
+        if (ffmpegLocation.isAvailable && !request.hasOption("--ffmpeg-location")) {
             request.addOption("--ffmpeg-location", ffmpegLocation.executable.absolutePath)
         }
 
-        if (nodeLocation.isAvailable) {
+        if (nodeLocation.isAvailable && request.getArguments("--js-runtimes")
+                ?.none { it?.startsWith("node:") == true } != false
+        ) {
             request.addOption("--js-runtimes", "node:${nodeLocation.executable.absolutePath}")
         }
 
-        if (denoLocation.isAvailable) {
+        if (denoLocation.isAvailable && request.getArguments("--js-runtimes")
+                ?.none { it?.startsWith("deno:") == true } != false
+        ) {
             request.addOption("--js-runtimes", "deno:${denoLocation.executable.absolutePath}")
         }
 
-        if (quickJsLocation.isAvailable) {
+        if (quickJsLocation.isAvailable && request.getArguments("--js-runtimes")
+                ?.none { it?.startsWith("quickjs:") == true } != false
+        ) {
             request.addOption("--js-runtimes", "quickjs:${quickJsLocation.executable.absolutePath}")
         }
 
-        if (request.buildCommand().contains("libaria2c.so")) {
+        if (request.buildCommand().contains("libaria2c.so") &&
+            request.getArguments("--external-downloader-args")
+                ?.none { it?.contains("--ca-certificate=") == true } != false
+        ) {
             request.addOption(
                 "--external-downloader-args",
                 "aria2c:--ca-certificate=$ENV_SSL_CERT_FILE"
             )
         }
 
-        if (!usingCacheDir) {
+        if (!usingCacheDir && !request.hasOption("--no-cache-dir")) {
             request.addOption("--no-cache-dir")
         }
 
-        request.addOption("--progress-delta", 0.1)
+        if (!request.hasOption("--progress-delta")) {
+            request.addOption("--progress-delta", 0.1)
+        }
 
         return mutableListOf(pythonLocation.executable.absolutePath, ytdlpPath!!.absolutePath) + request.buildCommand()
     }
@@ -398,7 +411,9 @@ object RuntimeManager {
             if (!successCodes.contains(exitCode)) {
                 // Check if process was manually killed (removed from map)
                 if (processId != null && !idProcessMap.containsKey(processId)) throw CanceledException()
-                throw ExecuteException(err)
+                // stderr is empty when redirectErrorStream is enabled. Preserve the
+                // merged output so the worker can classify the final HTTP failure.
+                throw ExecuteException(err.ifBlank { out }.takeLast(16_384))
             }
 
             ExecuteResponse(fullCommand, exitCode, System.currentTimeMillis() - startTime, out, err)

--- a/app/src/main/java/com/deniscerri/ytdl/core/RuntimeManager.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/core/RuntimeManager.kt
@@ -277,14 +277,25 @@ object RuntimeManager {
             request.addOption("--js-runtimes", "quickjs:${quickJsLocation.executable.absolutePath}")
         }
 
-        if (request.buildCommand().contains("libaria2c.so") &&
-            request.getArguments("--external-downloader-args")
-                ?.none { it?.contains("--ca-certificate=") == true } != false
-        ) {
-            request.addOption(
+        if (request.buildCommand().contains("libaria2c.so")) {
+            // Keep the CA path in the same aria2 namespace as its resume/tuning
+            // arguments. Separate aliases can override rather than merge in yt-dlp.
+            val certificateArgument = "--ca-certificate=$ENV_SSL_CERT_FILE"
+            val appended = request.appendToOptionArgument(
+                "--downloader-args",
+                "aria2c:",
+                certificateArgument,
+            ) || request.appendToOptionArgument(
                 "--external-downloader-args",
-                "aria2c:--ca-certificate=$ENV_SSL_CERT_FILE"
+                "aria2c:",
+                certificateArgument,
             )
+            if (!appended) {
+                request.addOption(
+                    "--external-downloader-args",
+                    "aria2c:$certificateArgument",
+                )
+            }
         }
 
         if (!usingCacheDir && !request.hasOption("--no-cache-dir")) {

--- a/app/src/main/java/com/deniscerri/ytdl/core/models/YTDLOptions.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/core/models/YTDLOptions.kt
@@ -49,6 +49,21 @@ class YTDLOptions {
         return options.containsKey(option)
     }
 
+    /**
+     * Extends one namespaced yt-dlp argument in place. Retried requests therefore
+     * keep one aria2 argument instead of adding a second option that may override it.
+     */
+    fun appendToArgument(option: String, argumentPrefix: String, suffix: String): Boolean {
+        val arguments = options[option] ?: return false
+        val index = arguments.indexOfFirst { it.startsWith(argumentPrefix) }
+        if (index < 0) return false
+
+        if (!arguments[index].contains(suffix)) {
+            arguments[index] = "${arguments[index].trim()} ${suffix.trim()}"
+        }
+        return true
+    }
+
     fun buildOptions(): List<String> {
         val commandList: MutableList<String> = mutableListOf()
         for ((option, value) in options) {

--- a/app/src/main/java/com/deniscerri/ytdl/core/models/YTDLRequest.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/core/models/YTDLRequest.kt
@@ -45,6 +45,11 @@ class YTDLRequest {
         return options.hasOption(option)
     }
 
+    /** Extends an existing namespaced downloader argument without duplicating it. */
+    fun appendToOptionArgument(option: String, argumentPrefix: String, suffix: String): Boolean {
+        return options.appendToArgument(option, argumentPrefix, suffix)
+    }
+
     fun buildCommand(): List<String> {
         val commandList: MutableList<String> = ArrayList()
         commandList.addAll(options.buildOptions())

--- a/app/src/main/java/com/deniscerri/ytdl/database/dao/DownloadDao.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/database/dao/DownloadDao.kt
@@ -99,6 +99,11 @@ interface DownloadDao {
     @Query("SELECT * FROM downloads WHERE status='Active'")
     fun getActiveDownloadsList() : List<DownloadItem>
 
+    // Emits a Room table change when an active item releases its network slot and
+    // enters local FFmpeg work, without reviving a cancelled item.
+    @Query("UPDATE downloads SET status='Active' WHERE id=:id AND status='Active'")
+    suspend fun notifyActiveDownloadChanged(id: Long)
+
     @Query("SELECT * FROM downloads WHERE url=:url AND status='Processing'")
     fun getProcessingDownloadsByUrl(url: String) : List<DownloadItem>
 

--- a/app/src/main/java/com/deniscerri/ytdl/database/dao/DownloadDao.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/database/dao/DownloadDao.kt
@@ -104,6 +104,11 @@ interface DownloadDao {
     @Query("UPDATE downloads SET status='Active' WHERE id=:id AND status='Active'")
     suspend fun notifyActiveDownloadChanged(id: Long)
 
+    // External resource changes do not update a row naturally. This no-op update
+    // wakes the observed queue without reviving paused or cancelled downloads.
+    @Query("UPDATE downloads SET status='Queued' WHERE status='Queued'")
+    suspend fun notifyQueuedDownloadsChanged()
+
     @Query("SELECT * FROM downloads WHERE url=:url AND status='Processing'")
     fun getProcessingDownloadsByUrl(url: String) : List<DownloadItem>
 

--- a/app/src/main/java/com/deniscerri/ytdl/database/models/VideoPreferences.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/database/models/VideoPreferences.kt
@@ -1,6 +1,7 @@
 package com.deniscerri.ytdl.database.models
 
 import android.os.Parcelable
+import com.deniscerri.ytdl.util.SubtitleLanguagePolicy
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -11,7 +12,7 @@ data class VideoPreferences (
     var sponsorBlockFilters: ArrayList<String> = arrayListOf(),
     var writeSubs: Boolean = false,
     var writeAutoSubs: Boolean = false,
-    var subsLanguages: String = "en.*,.*-orig",
+    var subsLanguages: String = SubtitleLanguagePolicy.SAFE_DEFAULT,
     var audioFormatIDs : ArrayList<String> = arrayListOf(),
     var removeAudio: Boolean = false,
     var alsoDownloadAsAudio: Boolean = false,

--- a/app/src/main/java/com/deniscerri/ytdl/database/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/database/viewmodel/DownloadViewModel.kt
@@ -44,6 +44,7 @@ import com.deniscerri.ytdl.util.Extensions.toListString
 import com.deniscerri.ytdl.util.FileUtil
 import com.deniscerri.ytdl.util.FormatUtil
 import com.deniscerri.ytdl.util.NotificationUtil
+import com.deniscerri.ytdl.util.SubtitleLanguagePolicy
 import com.deniscerri.ytdl.util.extractors.ytdlp.YTDLPUtil
 import com.deniscerri.ytdl.util.AlarmScheduler
 import com.deniscerri.ytdl.util.DownloadQueueUtil
@@ -302,7 +303,9 @@ class DownloadViewModel(private val application: Application) : AndroidViewModel
 
 
         val preferredAudioFormats = getPreferredAudioFormats(resultItem.formats)
-        val subsLanguages = sharedPreferences.getString("subs_lang", "en.*,.*-orig")!!
+        val subsLanguages = SubtitleLanguagePolicy.normalize(
+            sharedPreferences.getString("subs_lang", SubtitleLanguagePolicy.SAFE_DEFAULT),
+        )
 
         val videoPreferences = VideoPreferences(
             embedSubs,
@@ -462,7 +465,9 @@ class DownloadViewModel(private val application: Application) : AndroidViewModel
         val saveThumb = sharedPreferences.getBoolean("write_thumbnail", false)
         val embedThumb = sharedPreferences.getBoolean("embed_thumbnail", false)
         val cropThumb = sharedPreferences.getBoolean("crop_thumbnail", false)
-        val subsLanguages = sharedPreferences.getString("subs_lang", "en.*,.*-orig")!!
+        val subsLanguages = SubtitleLanguagePolicy.normalize(
+            sharedPreferences.getString("subs_lang", SubtitleLanguagePolicy.SAFE_DEFAULT),
+        )
 
         var customFileNameTemplate = when(historyItem.type) {
             DownloadType.audio -> sharedPreferences.getString("file_name_template_audio", "%(uploader).30B - %(title).170B")!!

--- a/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/downloading/DownloadSettingsModule.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/downloading/DownloadSettingsModule.kt
@@ -31,6 +31,19 @@ object DownloadSettingsModule : SettingModule {
         val context = pref.context
         val preferences = PreferenceManager.getDefaultSharedPreferences(context)
         when(pref.key) {
+            "smart_request_budget" -> {
+                // The ceiling is editable only when shared budgeting is active.
+                host.findPref("max_parallel_requests")?.isEnabled =
+                    preferences.getBoolean("smart_request_budget", true)
+                pref.setOnPreferenceChangeListener { _, newValue ->
+                    host.findPref("max_parallel_requests")?.isEnabled = newValue as Boolean
+                    host.refreshUI()
+                    true
+                }
+            }
+            "max_parallel_requests" -> {
+                pref.isEnabled = preferences.getBoolean("smart_request_budget", true)
+            }
             "remember_download_type" -> {
                 val rememberDownloadType = pref as SwitchPreferenceCompat
                 rememberDownloadType.setOnPreferenceChangeListener { _, newValue ->

--- a/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/processing/ProcessingSettingsModule.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/more/settings/processing/ProcessingSettingsModule.kt
@@ -13,6 +13,7 @@ import com.afollestad.materialdialogs.utils.MDUtil.getStringArray
 import com.deniscerri.ytdl.R
 import com.deniscerri.ytdl.ui.more.settings.SettingModule
 import com.deniscerri.ytdl.ui.more.settings.SettingHost
+import com.deniscerri.ytdl.util.SubtitleLanguagePolicy
 import com.deniscerri.ytdl.util.UiUtil
 import kotlinx.coroutines.launch
 import kotlin.collections.indexOf
@@ -85,9 +86,18 @@ object ProcessingSettingsModule : SettingModule {
             }
             "subs_lang" -> {
                 pref.apply {
-                    summary = prefs.getString("subs_lang", "en.*,.*-orig")!!
+                    val subtitleLanguages = SubtitleLanguagePolicy.normalize(
+                        prefs.getString("subs_lang", SubtitleLanguagePolicy.SAFE_DEFAULT),
+                    )
+                    summary = subtitleLanguages
                     setOnPreferenceClickListener {
-                        UiUtil.showSubtitleLanguagesDialog(host.getHostContext(), listOf(), prefs.getString("subs_lang", "en.*,.*-orig")!!){
+                        UiUtil.showSubtitleLanguagesDialog(
+                            host.getHostContext(),
+                            listOf(),
+                            SubtitleLanguagePolicy.normalize(
+                                prefs.getString("subs_lang", SubtitleLanguagePolicy.SAFE_DEFAULT),
+                            ),
+                        ) {
                             prefs.edit(commit = true) {
                                 putString(pref.key, it)
                             }

--- a/app/src/main/java/com/deniscerri/ytdl/util/DeviceResourceMonitor.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/DeviceResourceMonitor.kt
@@ -1,0 +1,48 @@
+package com.deniscerri.ytdl.util
+
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import android.os.Build
+import android.os.PowerManager
+import java.io.File
+
+/** Reads low-cost local signals used to avoid download/FFmpeg pile-ups on a hot phone. */
+class DeviceResourceMonitor(context: Context) {
+    private val applicationContext = context.applicationContext
+    private val powerManager =
+        applicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager
+
+    fun snapshot(): DeviceResourcePolicy.Snapshot {
+        return DeviceResourcePolicy.Snapshot(
+            cpuLoadPerCore = readCpuLoadPerCore(),
+            thermalStatus = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                powerManager.currentThermalStatus
+            } else {
+                null
+            },
+            batteryTemperatureCelsius = readBatteryTemperature(),
+        )
+    }
+
+    private fun readCpuLoadPerCore(): Double? = runCatching {
+        val oneMinuteLoad = File("/proc/loadavg")
+            .readText()
+            .substringBefore(' ')
+            .toDouble()
+        oneMinuteLoad / Runtime.getRuntime().availableProcessors().coerceAtLeast(1)
+    }.getOrNull()
+
+    private fun readBatteryTemperature(): Float? {
+        val battery = applicationContext.registerReceiver(
+            null,
+            IntentFilter(Intent.ACTION_BATTERY_CHANGED),
+        ) ?: return null
+        val tenthsCelsius = battery.getIntExtra(
+            BatteryManager.EXTRA_TEMPERATURE,
+            Int.MIN_VALUE,
+        )
+        return if (tenthsCelsius == Int.MIN_VALUE) null else tenthsCelsius / 10f
+    }
+}

--- a/app/src/main/java/com/deniscerri/ytdl/util/DeviceResourcePolicy.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/DeviceResourcePolicy.kt
@@ -1,0 +1,60 @@
+package com.deniscerri.ytdl.util
+
+import kotlin.math.min
+
+/** Converts CPU and temperature samples into bounded scheduling limits. */
+object DeviceResourcePolicy {
+    enum class Pressure {
+        NORMAL,
+        ELEVATED,
+        HIGH,
+        CRITICAL,
+    }
+
+    data class Snapshot(
+        val cpuLoadPerCore: Double?,
+        val thermalStatus: Int?,
+        val batteryTemperatureCelsius: Float?,
+    )
+
+    fun pressure(snapshot: Snapshot): Pressure {
+        val thermal = snapshot.thermalStatus
+        val battery = snapshot.batteryTemperatureCelsius
+        val cpu = snapshot.cpuLoadPerCore
+
+        if ((thermal != null && thermal >= 3) || (battery != null && battery >= 48f)) {
+            return Pressure.CRITICAL
+        }
+        if ((thermal != null && thermal >= 2) ||
+            (battery != null && battery >= 44f) ||
+            (cpu != null && cpu >= 1.15)
+        ) {
+            return Pressure.HIGH
+        }
+        if ((thermal != null && thermal >= 1) ||
+            (battery != null && battery >= 40f) ||
+            (cpu != null && cpu >= 0.85)
+        ) {
+            return Pressure.ELEVATED
+        }
+        return Pressure.NORMAL
+    }
+
+    fun limitDownloads(requested: Int, pressure: Pressure): Int = when (pressure) {
+        Pressure.NORMAL -> requested.coerceAtLeast(1)
+        Pressure.ELEVATED -> min(requested.coerceAtLeast(1), 2)
+        Pressure.HIGH -> 1
+        Pressure.CRITICAL -> 0
+    }
+
+    fun limitFragments(requested: Int, pressure: Pressure): Int = when (pressure) {
+        Pressure.NORMAL -> requested.coerceAtLeast(1)
+        Pressure.ELEVATED -> min(requested.coerceAtLeast(1), 4)
+        Pressure.HIGH -> min(requested.coerceAtLeast(1), 2)
+        Pressure.CRITICAL -> 1
+    }
+
+    fun allowPostProcessingOverlap(pressure: Pressure): Boolean {
+        return pressure == Pressure.NORMAL
+    }
+}

--- a/app/src/main/java/com/deniscerri/ytdl/util/DownloadConnectivityMonitor.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/DownloadConnectivityMonitor.kt
@@ -1,0 +1,64 @@
+package com.deniscerri.ytdl.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+
+/** Tracks whether Android currently has a validated default internet connection. */
+class DownloadConnectivityMonitor private constructor(context: Context) {
+    private val connectivityManager =
+        context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private val _isOnline = MutableStateFlow(readCurrentState())
+    val isOnline = _isOnline.asStateFlow()
+
+    private val callback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) = refresh()
+        override fun onLost(network: Network) = refresh()
+        override fun onUnavailable() = refresh()
+
+        override fun onCapabilitiesChanged(
+            network: Network,
+            networkCapabilities: NetworkCapabilities,
+        ) {
+            _isOnline.value = isUsable(networkCapabilities)
+        }
+    }
+
+    init {
+        connectivityManager.registerDefaultNetworkCallback(callback)
+    }
+
+    suspend fun awaitOnline() {
+        isOnline.filter { it }.first()
+    }
+
+    private fun refresh() {
+        _isOnline.value = readCurrentState()
+    }
+
+    private fun readCurrentState(): Boolean {
+        val network = connectivityManager.activeNetwork ?: return false
+        return isUsable(connectivityManager.getNetworkCapabilities(network))
+    }
+
+    private fun isUsable(capabilities: NetworkCapabilities?): Boolean {
+        return capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true &&
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    }
+
+    companion object {
+        @Volatile
+        private var instance: DownloadConnectivityMonitor? = null
+
+        fun getInstance(context: Context): DownloadConnectivityMonitor {
+            return instance ?: synchronized(this) {
+                instance ?: DownloadConnectivityMonitor(context).also { instance = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/deniscerri/ytdl/util/DownloadNetworkPolicy.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/DownloadNetworkPolicy.kt
@@ -1,0 +1,42 @@
+package com.deniscerri.ytdl.util
+
+import kotlin.math.min
+
+/**
+ * Keeps item-level and fragment-level concurrency inside one shared request budget.
+ * This prevents their settings from multiplying into an unexpectedly large number
+ * of simultaneous connections.
+ */
+object DownloadNetworkPolicy {
+    const val DEFAULT_CONCURRENT_DOWNLOADS = 2
+    const val DEFAULT_CONCURRENT_FRAGMENTS = 4
+    const val DEFAULT_MAX_PARALLEL_REQUESTS = 8
+
+    fun effectiveDownloadLimit(
+        requestedDownloads: Int,
+        maxParallelRequests: Int,
+        budgetingEnabled: Boolean,
+    ): Int {
+        val downloads = requestedDownloads.coerceAtLeast(1)
+        if (!budgetingEnabled) return downloads
+        return min(downloads, maxParallelRequests.coerceAtLeast(1))
+    }
+
+    fun effectiveFragmentLimit(
+        requestedFragments: Int,
+        requestedDownloads: Int,
+        maxParallelRequests: Int,
+        budgetingEnabled: Boolean,
+    ): Int {
+        val fragments = requestedFragments.coerceAtLeast(1)
+        if (!budgetingEnabled) return fragments
+
+        val downloads = effectiveDownloadLimit(
+            requestedDownloads = requestedDownloads,
+            maxParallelRequests = maxParallelRequests,
+            budgetingEnabled = true,
+        )
+        val fragmentsPerDownload = maxParallelRequests.coerceAtLeast(1) / downloads
+        return min(fragments, fragmentsPerDownload.coerceAtLeast(1))
+    }
+}

--- a/app/src/main/java/com/deniscerri/ytdl/util/DownloadPipelinePolicy.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/DownloadPipelinePolicy.kt
@@ -1,0 +1,49 @@
+package com.deniscerri.ytdl.util
+
+import kotlin.math.min
+
+/** Separates network transfer slots from bounded local post-processing work. */
+object DownloadPipelinePolicy {
+    private val postProcessingPrefixes = listOf(
+        "[Merger]",
+        "[ExtractAudio]",
+        "[VideoConvertor]",
+        "[VideoRemuxer]",
+        "[Fixup",
+        "[EmbedSubtitle]",
+        "[Metadata]",
+        "[ModifyChapters]",
+        "[SplitChapters]",
+        "[ThumbnailsConvertor]",
+    )
+
+    fun isPostProcessingOutput(line: String): Boolean {
+        val trimmed = line.trimStart()
+        return postProcessingPrefixes.any(trimmed::startsWith)
+    }
+
+    /**
+     * Post-processing does not consume a network slot, but the queue may launch at
+     * most one process beyond the network limit to avoid an unbounded FFmpeg pile-up.
+     */
+    fun availableNetworkSlots(
+        networkLimit: Int,
+        runningIds: Collection<Long>,
+        postProcessingIds: Set<Long>,
+        pipelineEnabled: Boolean,
+    ): Int {
+        val safeNetworkLimit = networkLimit.coerceAtLeast(1)
+        val networkProcesses = runningIds.count { it !in postProcessingIds }
+        val availableNetwork = (safeNetworkLimit - networkProcesses).coerceAtLeast(0)
+        if (!pipelineEnabled) {
+            return min(
+                availableNetwork,
+                (safeNetworkLimit - runningIds.size).coerceAtLeast(0),
+            )
+        }
+
+        val totalProcessLimit = safeNetworkLimit + 1
+        val availableProcesses = (totalProcessLimit - runningIds.size).coerceAtLeast(0)
+        return min(availableNetwork, availableProcesses)
+    }
+}

--- a/app/src/main/java/com/deniscerri/ytdl/util/HttpRetryPolicy.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/HttpRetryPolicy.kt
@@ -1,0 +1,125 @@
+package com.deniscerri.ytdl.util
+
+/**
+ * Classifies failures that are safe to retry at the worker level after yt-dlp has
+ * exhausted its own retry handling. Permanent client, authentication and permission
+ * failures are deliberately excluded to avoid loops and unnecessary server traffic.
+ */
+object HttpRetryPolicy {
+    const val MAX_TRANSIENT_RETRIES = 2
+    const val MAX_EXPIRED_MEDIA_URL_RETRIES = 1
+
+    private val transientStatusCodes = setOf(
+        408,
+        425,
+        429,
+        500,
+        502,
+        503,
+        504,
+        520,
+        521,
+        522,
+        523,
+        524,
+    )
+    private val statusPattern = Regex(
+        "(?:HTTP Error|HTTP status(?: code)?|status code)\\s*[:=]?\\s*(\\d{3})",
+        RegexOption.IGNORE_CASE,
+    )
+    private val retryAfterPattern = Regex(
+        "Retry-After(?:\\s+header)?\\s*[:=]\\s*(\\d+)",
+        RegexOption.IGNORE_CASE,
+    )
+    private val expiredMediaMarkers = listOf(
+        "unable to download video data",
+        "unable to download video",
+        "unable to download audio",
+        "unable to download fragment",
+        "fragment",
+    )
+    private val authenticationMarkers = listOf(
+        "sign in",
+        "log in",
+        "login",
+        "cookie",
+        "authentication",
+        "private video",
+        "members-only",
+        "confirm you're not a bot",
+    )
+
+    enum class Reason {
+        TRANSIENT_HTTP,
+        EXPIRED_MEDIA_URL,
+    }
+
+    data class Decision(
+        val reason: Reason,
+        val statusCode: Int,
+        val delaySeconds: Long,
+    )
+
+    /** Returns a bounded retry decision, or null when the failure must remain terminal. */
+    fun nextRetry(
+        output: String,
+        completedTransientRetries: Int,
+        completedExpiredMediaUrlRetries: Int,
+    ): Decision? {
+        val statusCode = statusCode(output) ?: return null
+
+        if (statusCode in transientStatusCodes &&
+            completedTransientRetries < MAX_TRANSIENT_RETRIES
+        ) {
+            return Decision(
+                reason = Reason.TRANSIENT_HTTP,
+                statusCode = statusCode,
+                delaySeconds = retryDelaySeconds(
+                    output = output,
+                    statusCode = statusCode,
+                    completedRetries = completedTransientRetries,
+                ),
+            )
+        }
+
+        if (statusCode == 403 &&
+            completedExpiredMediaUrlRetries < MAX_EXPIRED_MEDIA_URL_RETRIES &&
+            isExpiredMediaUrlFailure(output)
+        ) {
+            return Decision(
+                reason = Reason.EXPIRED_MEDIA_URL,
+                statusCode = statusCode,
+                delaySeconds = 1,
+            )
+        }
+
+        return null
+    }
+
+    fun statusCode(output: String): Int? = statusPattern.findAll(output)
+        .lastOrNull()
+        ?.groupValues
+        ?.getOrNull(1)
+        ?.toIntOrNull()
+
+    private fun isExpiredMediaUrlFailure(output: String): Boolean {
+        val normalized = output.lowercase()
+        return expiredMediaMarkers.any(normalized::contains) &&
+            authenticationMarkers.none(normalized::contains)
+    }
+
+    private fun retryDelaySeconds(
+        output: String,
+        statusCode: Int,
+        completedRetries: Int,
+    ): Long {
+        val retryAfter = retryAfterPattern.find(output)
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.toLongOrNull()
+        if (retryAfter != null) return retryAfter.coerceIn(5, 300)
+
+        val delays = if (statusCode == 429) longArrayOf(30, 90) else longArrayOf(5, 15)
+        return delays[completedRetries.coerceIn(delays.indices)]
+    }
+}

--- a/app/src/main/java/com/deniscerri/ytdl/util/SubtitleLanguagePolicy.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/SubtitleLanguagePolicy.kt
@@ -1,0 +1,27 @@
+package com.deniscerri.ytdl.util
+
+/** Keeps subtitle defaults narrow and identifies optional subtitle-only failures. */
+object SubtitleLanguagePolicy {
+    const val LEGACY_DEFAULT = "en.*,.*-orig"
+    const val SAFE_DEFAULT = "en,.*-orig"
+
+    private val failureMarkers = listOf(
+        "unable to download video subtitles",
+        "unable to download subtitles",
+        "subtitle download failed",
+    )
+
+    /** Migrates the old translation wildcard without changing custom selections. */
+    fun normalize(value: String?): String {
+        val normalized = value?.trim().orEmpty()
+        return when (normalized) {
+            "", LEGACY_DEFAULT -> SAFE_DEFAULT
+            else -> normalized
+        }
+    }
+
+    fun isDownloadFailure(output: String): Boolean {
+        val normalized = output.lowercase()
+        return failureMarkers.any(normalized::contains)
+    }
+}

--- a/app/src/main/java/com/deniscerri/ytdl/util/SubtitleRecoveryCoordinator.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/SubtitleRecoveryCoordinator.kt
@@ -1,0 +1,66 @@
+package com.deniscerri.ytdl.util
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Keeps subtitle decisions pending while the app is backgrounded, then delivers the
+ * user's choice back to the worker when MainActivity is opened.
+ */
+object SubtitleRecoveryCoordinator {
+    enum class Action {
+        CONTINUE,
+        RETRY,
+        CANCEL,
+    }
+
+    data class Request(
+        val requestId: Long = SubtitleRecoveryCoordinator.nextRequestId.incrementAndGet(),
+        val downloadId: Long,
+        val title: String,
+        val message: String,
+    )
+
+    private data class Pending(
+        val request: Request,
+        val result: CompletableDeferred<Action>,
+    )
+
+    private val nextRequestId = AtomicLong(System.currentTimeMillis())
+    private val lock = Any()
+    private val pending = linkedMapOf<Long, Pending>()
+    private val _requests = MutableStateFlow<List<Request>>(emptyList())
+    val requests = _requests.asStateFlow()
+
+    suspend fun awaitDecision(request: Request): Action {
+        val result = CompletableDeferred<Action>()
+        synchronized(lock) {
+            pending[request.requestId] = Pending(request, result)
+            publishLocked()
+        }
+
+        return try {
+            result.await()
+        } finally {
+            synchronized(lock) {
+                pending.remove(request.requestId)
+                publishLocked()
+            }
+        }
+    }
+
+    fun resolve(requestId: Long, action: Action) {
+        val result = synchronized(lock) {
+            val target = pending.remove(requestId) ?: return
+            publishLocked()
+            target.result
+        }
+        result.complete(action)
+    }
+
+    private fun publishLocked() {
+        _requests.value = pending.values.map { it.request }
+    }
+}

--- a/app/src/main/java/com/deniscerri/ytdl/util/UiUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/UiUtil.kt
@@ -1507,7 +1507,14 @@ object UiUtil {
                     items[0].videoPreferences.subsLanguages
                 }else {
                     ""
-                }.ifEmpty { sharedPreferences.getString("subs_lang", "en.*,.*-orig")!! }
+                }.ifEmpty {
+                    SubtitleLanguagePolicy.normalize(
+                        sharedPreferences.getString(
+                            "subs_lang",
+                            SubtitleLanguagePolicy.SAFE_DEFAULT,
+                        ),
+                    )
+                }
 
                 val availabeSubtitles = if (items.size == 1) items[0].availableSubtitles else listOf()
                 showSubtitleLanguagesDialog(context, availabeSubtitles, currentSubtitleLang){

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/ytdlp/YTDLPUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/ytdlp/YTDLPUtil.kt
@@ -33,6 +33,7 @@ import com.deniscerri.ytdl.util.Extensions.isYoutubeURL
 import com.deniscerri.ytdl.util.Extensions.isYoutubeWatchVideosURL
 import com.deniscerri.ytdl.util.Extensions.readJsonValue
 import com.deniscerri.ytdl.util.Extensions.toStringDuration
+import com.deniscerri.ytdl.util.DownloadNetworkPolicy
 import com.deniscerri.ytdl.util.FileUtil
 import com.deniscerri.ytdl.util.FormatUtil
 import com.deniscerri.ytdl.util.SubtitleLanguagePolicy
@@ -973,7 +974,29 @@ class YTDLPUtil(private val context: Context, private val commandTemplateDao: Co
             //request.addOption("--external-downloader-args", "aria2c:\"--check-certificate=false\"")
         }
 
-        val concurrentFragments = sharedPreferences.getInt("concurrent_fragments", 1)
+        val requestedDownloads = sharedPreferences.getInt(
+            "concurrent_downloads",
+            DownloadNetworkPolicy.DEFAULT_CONCURRENT_DOWNLOADS,
+        )
+        val requestedFragments = sharedPreferences.getInt(
+            "concurrent_fragments",
+            DownloadNetworkPolicy.DEFAULT_CONCURRENT_FRAGMENTS,
+        )
+        val maxParallelRequests = sharedPreferences.getInt(
+            "max_parallel_requests",
+            DownloadNetworkPolicy.DEFAULT_MAX_PARALLEL_REQUESTS,
+        )
+        // Calculate -N from the same budget used by DownloadWorker so item and
+        // fragment concurrency cannot multiply past the configured ceiling.
+        val concurrentFragments = DownloadNetworkPolicy.effectiveFragmentLimit(
+            requestedFragments = requestedFragments,
+            requestedDownloads = requestedDownloads,
+            maxParallelRequests = maxParallelRequests,
+            budgetingEnabled = sharedPreferences.getBoolean(
+                "smart_request_budget",
+                true,
+            ),
+        )
         if (concurrentFragments > 1) request.addOption("-N", concurrentFragments)
 
         val retries = sharedPreferences.getString("retries", "")!!

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/ytdlp/YTDLPUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/ytdlp/YTDLPUtil.kt
@@ -35,6 +35,7 @@ import com.deniscerri.ytdl.util.Extensions.readJsonValue
 import com.deniscerri.ytdl.util.Extensions.toStringDuration
 import com.deniscerri.ytdl.util.FileUtil
 import com.deniscerri.ytdl.util.FormatUtil
+import com.deniscerri.ytdl.util.SubtitleLanguagePolicy
 import com.google.gson.Gson
 import com.google.gson.Strictness
 import com.google.gson.reflect.TypeToken
@@ -761,13 +762,6 @@ class YTDLPUtil(private val context: Context, private val commandTemplateDao: Co
         return final
     }
 
-    private fun MutableList<String>.addOption(vararg options: String) {
-        options.forEach {
-            this.add(it)
-        }
-    }
-
-
     private fun YTDLRequest.setYoutubeExtractorArgs(url: String?) {
         val extractorArgs = mutableListOf<String>()
         val playerClients = mutableSetOf<String>()
@@ -893,7 +887,10 @@ class YTDLPUtil(private val context: Context, private val commandTemplateDao: Co
     }
 
     @SuppressLint("RestrictedApi")
-    fun buildYTDLRequest(downloadItem: DownloadItem) : YTDLRequest {
+    fun buildYTDLRequest(
+        downloadItem: DownloadItem,
+        suppressSubtitles: Boolean = false,
+    ) : YTDLRequest {
         var useItemURL = sharedPreferences.getBoolean("use_itemurl_instead_playlisturl", false)
         // for /releases youtube channel playlists that have playlists inside of them, cant use indexing or match filter id, so download on its own
         if (downloadItem.url.isYoutubeURL() && downloadItem.url.getIDFromYoutubeURL() == null) {
@@ -1560,15 +1557,15 @@ class YTDLPUtil(private val context: Context, private val commandTemplateDao: Co
 
                 request.addOption("-f", f.toString().replace("/$".toRegex(), ""))
 
-                if (downloadItem.videoPreferences.writeSubs){
+                if (!suppressSubtitles && downloadItem.videoPreferences.writeSubs){
                     request.addOption("--write-subs")
                 }
 
-                if(downloadItem.videoPreferences.writeAutoSubs){
+                if (!suppressSubtitles && downloadItem.videoPreferences.writeAutoSubs){
                     request.addOption("--write-auto-subs")
                 }
 
-                if (downloadItem.videoPreferences.embedSubs) {
+                if (!suppressSubtitles && downloadItem.videoPreferences.embedSubs) {
                     if (sharedPreferences.getBoolean("no_keep_subs", false) && (downloadItem.videoPreferences.writeSubs || downloadItem.videoPreferences.writeAutoSubs)) {
                         request.addOption("--compat-options", "no-keep-subs")
                     }
@@ -1576,13 +1573,22 @@ class YTDLPUtil(private val context: Context, private val commandTemplateDao: Co
                     request.addOption("--embed-subs")
                 }
 
-                if (downloadItem.videoPreferences.embedSubs || downloadItem.videoPreferences.writeSubs || downloadItem.videoPreferences.writeAutoSubs){
+                if (!suppressSubtitles &&
+                    (downloadItem.videoPreferences.embedSubs ||
+                        downloadItem.videoPreferences.writeSubs ||
+                        downloadItem.videoPreferences.writeAutoSubs)
+                ) {
                     val subFormat = sharedPreferences.getString("sub_format", "")
                     if(subFormat!!.isNotBlank()){
                         request.addOption("--sub-format", "${subFormat}/best")
                         request.addOption("--convert-subtitles", subFormat)
                     }
-                    request.addOption("--sub-langs", downloadItem.videoPreferences.subsLanguages.ifEmpty { "en.*,.*-orig" })
+                    request.addOption(
+                        "--sub-langs",
+                        SubtitleLanguagePolicy.normalize(
+                            downloadItem.videoPreferences.subsLanguages,
+                        ),
+                    )
                 }
 
                 var copyStream = ""
@@ -1671,9 +1677,9 @@ class YTDLPUtil(private val context: Context, private val commandTemplateDao: Co
         val conf = File(cache.absolutePath + "/${System.currentTimeMillis()}${UUID.randomUUID()}.txt")
         conf.createNewFile()
         conf.writeText(request.toString())
-        val tmp = mutableListOf<String>()
-        tmp.addOption("--config-locations", conf.absolutePath)
-        ytDlRequest.addCommands(tmp)
+        // Keep the generated config visible to cleanup when a recovery action
+        // rebuilds the request without subtitle options.
+        ytDlRequest.addOption("--config-locations", conf.absolutePath)
 
         val ytdlpCache = File(FileUtil.getCacheYTDLPPath(context))
         ytDlRequest.addOption("--cache-dir", ytdlpCache.absolutePath)

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/ytdlp/YTDLPUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/ytdlp/YTDLPUtil.kt
@@ -969,9 +969,6 @@ class YTDLPUtil(private val context: Context, private val commandTemplateDao: Co
         val aria2 = sharedPreferences.getBoolean("aria2", false)
         if (aria2) {
             ytDlRequest.addOption("--downloader", "libaria2c.so")
-            //request.addOption("--external-downloader-args", "aria2c:\"--summary-interval=1\"")
-            //ytDlRequest.addOption("--no-check-certificates")
-            //request.addOption("--external-downloader-args", "aria2c:\"--check-certificate=false\"")
         }
 
         val requestedDownloads = sharedPreferences.getInt(
@@ -998,6 +995,26 @@ class YTDLPUtil(private val context: Context, private val commandTemplateDao: Co
             ),
         )
         if (concurrentFragments > 1) request.addOption("-N", concurrentFragments)
+        if (aria2) {
+            // Reuse partial data and keep aria2 inside the same bounded fragment
+            // concurrency selected by DownloadNetworkPolicy.
+            request.addOption(
+                "--downloader-args",
+                "aria2c:-x$concurrentFragments -s$concurrentFragments -k1M " +
+                    "--continue=true --file-allocation=none --auto-file-renaming=false " +
+                    "--max-tries=5 --retry-wait=3 --connect-timeout=15 --timeout=30",
+            )
+        }
+
+        if (sharedPreferences.getBoolean("smart_request_budget", true)) {
+            // Let yt-dlp perform its normal bounded recovery before the worker-level
+            // HTTP policy decides whether another complete attempt is justified.
+            request.addOption("--retry-sleep", "http:exp=1:20")
+            request.addOption("--retry-sleep", "fragment:exp=1:10")
+            request.addOption("--retry-sleep", "extractor:exp=1:20")
+            request.addOption("--extractor-retries", 5)
+            request.addOption("--sleep-requests", "0.15")
+        }
 
         val retries = sharedPreferences.getString("retries", "")!!
         val fragmentRetries = sharedPreferences.getString("fragment_retries", "")!!
@@ -1050,6 +1067,10 @@ class YTDLPUtil(private val context: Context, private val commandTemplateDao: Co
         if(downloadItem.type != DownloadType.command){
             if (sharedPreferences.getBoolean("no_part", false)){
                 request.addOption("--no-part")
+            } else {
+                // Explicit .part files keep interrupted media resumable. FFmpeg only
+                // sees the file after yt-dlp reports a completed download stage.
+                request.addOption("--part")
             }
 
             if (sharedPreferences.getBoolean("trim_filenames", true)) {

--- a/app/src/main/java/com/deniscerri/ytdl/util/extractors/ytdlp/YTDLPUtil.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/util/extractors/ytdlp/YTDLPUtil.kt
@@ -24,6 +24,8 @@ import com.deniscerri.ytdl.database.models.YoutubeGeneratePoTokenItem
 import com.deniscerri.ytdl.database.models.YoutubePlayerClientItem
 import com.deniscerri.ytdl.database.viewmodel.ResultViewModel
 import com.deniscerri.ytdl.util.BgUtilsPoTokenGeneratorUtil
+import com.deniscerri.ytdl.util.DeviceResourceMonitor
+import com.deniscerri.ytdl.util.DeviceResourcePolicy
 import com.deniscerri.ytdl.util.Extensions.getIDFromYoutubeURL
 import com.deniscerri.ytdl.util.Extensions.getIntByAny
 import com.deniscerri.ytdl.util.Extensions.getStringByAny
@@ -985,7 +987,7 @@ class YTDLPUtil(private val context: Context, private val commandTemplateDao: Co
         )
         // Calculate -N from the same budget used by DownloadWorker so item and
         // fragment concurrency cannot multiply past the configured ceiling.
-        val concurrentFragments = DownloadNetworkPolicy.effectiveFragmentLimit(
+        var concurrentFragments = DownloadNetworkPolicy.effectiveFragmentLimit(
             requestedFragments = requestedFragments,
             requestedDownloads = requestedDownloads,
             maxParallelRequests = maxParallelRequests,
@@ -994,6 +996,15 @@ class YTDLPUtil(private val context: Context, private val commandTemplateDao: Co
                 true,
             ),
         )
+        if (sharedPreferences.getBoolean("device_resource_protection", true)) {
+            val pressure = DeviceResourcePolicy.pressure(
+                DeviceResourceMonitor(context).snapshot(),
+            )
+            concurrentFragments = DeviceResourcePolicy.limitFragments(
+                concurrentFragments,
+                pressure,
+            )
+        }
         if (concurrentFragments > 1) request.addOption("-N", concurrentFragments)
         if (aria2) {
             // Reuse partial data and keep aria2 inside the same bounded fragment

--- a/app/src/main/java/com/deniscerri/ytdl/work/DownloadWorker.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/work/DownloadWorker.kt
@@ -35,6 +35,8 @@ import com.deniscerri.ytdl.util.Extensions.toStringDuration
 import com.deniscerri.ytdl.util.FileUtil
 import com.deniscerri.ytdl.util.HttpRetryPolicy
 import com.deniscerri.ytdl.util.NotificationUtil
+import com.deniscerri.ytdl.util.SubtitleLanguagePolicy
+import com.deniscerri.ytdl.util.SubtitleRecoveryCoordinator
 import com.deniscerri.ytdl.util.WorkerEventBus
 import com.deniscerri.ytdl.util.extractors.ytdlp.YTDLPUtil
 import kotlinx.coroutines.CancellationException
@@ -222,7 +224,7 @@ class DownloadWorker(
                             true
                         ) && File(FileUtil.formatPath(downloadItem.downloadPath)).canWrite())
 
-                        val request = ytdlpUtil.buildYTDLRequest(downloadItem)
+                        var request = ytdlpUtil.buildYTDLRequest(downloadItem)
 
                         // DISABLED BECAUSE YT_DLP CONSIDERS DOWNLOAD FAILURE IF -U PART FAILS, ytdlnis #1043
     //                    val updateYTDLP = sharedPreferences.getBoolean("update_ytdlp_while_downloading", false)
@@ -336,38 +338,96 @@ class DownloadWorker(
                                         completedTransientRetries = completedTransientRetries,
                                         completedExpiredMediaUrlRetries =
                                             completedExpiredMediaUrlRetries,
-                                    ) ?: throw error
+                                    )
 
-                                    when (retry.reason) {
-                                        HttpRetryPolicy.Reason.TRANSIENT_HTTP ->
-                                            completedTransientRetries += 1
-                                        HttpRetryPolicy.Reason.EXPIRED_MEDIA_URL ->
-                                            completedExpiredMediaUrlRetries += 1
+                                    if (retry != null) {
+                                        when (retry.reason) {
+                                            HttpRetryPolicy.Reason.TRANSIENT_HTTP ->
+                                                completedTransientRetries += 1
+                                            HttpRetryPolicy.Reason.EXPIRED_MEDIA_URL ->
+                                                completedExpiredMediaUrlRetries += 1
+                                        }
+
+                                        val retryMessage = context.getString(
+                                            R.string.http_recovery_retry,
+                                            retry.statusCode,
+                                            retry.delaySeconds,
+                                        )
+                                        logString.appendLine(retryMessage)
+                                        WorkerEventBus.post(
+                                            WorkerProgress(
+                                                0,
+                                                retryMessage,
+                                                downloadItem.id,
+                                                downloadItem.logID,
+                                            ),
+                                        )
+                                        notificationUtil.updateDownloadNotification(
+                                            downloadItem.id.toInt(),
+                                            retryMessage,
+                                            0,
+                                            0,
+                                            downloadItem.title.ifEmpty { downloadItem.url },
+                                            NotificationUtil.Companion.DOWNLOAD_SERVICE_CHANNEL_ID,
+                                        )
+                                        delay(retry.delaySeconds * 1000)
+                                        continue
                                     }
 
-                                    val retryMessage = context.getString(
-                                        R.string.http_recovery_retry,
-                                        retry.statusCode,
-                                        retry.delaySeconds,
-                                    )
-                                    logString.appendLine(retryMessage)
-                                    WorkerEventBus.post(
-                                        WorkerProgress(
+                                    if (SubtitleLanguagePolicy.isDownloadFailure(failureOutput)) {
+                                        val decisionMessage = context.getString(
+                                            R.string.subtitle_failure_decision_message,
+                                        )
+                                        notificationUtil.updateDownloadNotification(
+                                            downloadItem.id.toInt(),
+                                            context.getString(R.string.action_required_open_app),
                                             0,
-                                            retryMessage,
-                                            downloadItem.id,
-                                            downloadItem.logID,
-                                        ),
-                                    )
-                                    notificationUtil.updateDownloadNotification(
-                                        downloadItem.id.toInt(),
-                                        retryMessage,
-                                        0,
-                                        0,
-                                        downloadItem.title.ifEmpty { downloadItem.url },
-                                        NotificationUtil.Companion.DOWNLOAD_SERVICE_CHANNEL_ID,
-                                    )
-                                    delay(retry.delaySeconds * 1000)
+                                            0,
+                                            downloadItem.title.ifEmpty { downloadItem.url },
+                                            NotificationUtil.Companion.DOWNLOAD_SERVICE_CHANNEL_ID,
+                                        )
+
+                                        when (SubtitleRecoveryCoordinator.awaitDecision(
+                                            SubtitleRecoveryCoordinator.Request(
+                                                downloadId = downloadItem.id,
+                                                title = downloadItem.title.ifEmpty {
+                                                    downloadItem.url
+                                                },
+                                                message = decisionMessage,
+                                            ),
+                                        )) {
+                                            SubtitleRecoveryCoordinator.Action.CONTINUE -> {
+                                                FileUtil.deleteConfigFiles(request)
+                                                request = ytdlpUtil.buildYTDLRequest(
+                                                    downloadItem,
+                                                    suppressSubtitles = true,
+                                                )
+                                                completedTransientRetries = 0
+                                                completedExpiredMediaUrlRetries = 0
+                                                logString.appendLine(
+                                                    context.getString(
+                                                        R.string.continuing_without_subtitles,
+                                                    ),
+                                                )
+                                                continue
+                                            }
+
+                                            SubtitleRecoveryCoordinator.Action.RETRY -> {
+                                                completedTransientRetries = 0
+                                                completedExpiredMediaUrlRetries = 0
+                                                continue
+                                            }
+
+                                            SubtitleRecoveryCoordinator.Action.CANCEL -> {
+                                                downloadItem.status =
+                                                    DownloadRepository.Status.Cancelled.toString()
+                                                dao.update(downloadItem)
+                                                throw SubtitleRecoveryCanceledException()
+                                            }
+                                        }
+                                    }
+
+                                    throw error
                                 }
                             }
 
@@ -657,5 +717,7 @@ class DownloadWorker(
         val downloadItemID: Long,
         val logItemID: Long?
     )
+
+    private class SubtitleRecoveryCanceledException : CancellationException()
 
 }

--- a/app/src/main/java/com/deniscerri/ytdl/work/DownloadWorker.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/work/DownloadWorker.kt
@@ -34,6 +34,7 @@ import com.deniscerri.ytdl.util.Extensions.getMediaDuration
 import com.deniscerri.ytdl.util.Extensions.toStringDuration
 import com.deniscerri.ytdl.util.FileUtil
 import com.deniscerri.ytdl.util.DownloadNetworkPolicy
+import com.deniscerri.ytdl.util.DownloadPipelinePolicy
 import com.deniscerri.ytdl.util.HttpRetryPolicy
 import com.deniscerri.ytdl.util.NotificationUtil
 import com.deniscerri.ytdl.util.SubtitleLanguagePolicy
@@ -56,6 +57,8 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.security.MessageDigest
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.collections.addAll
 import kotlin.random.Random
 
@@ -145,6 +148,11 @@ class DownloadWorker(
         val minDelay = downloadDelay.split("-")[0].toFloat()
         val maxDelay = downloadDelay.split("-")[1].toFloat()
         val hasDownloadDelay = minDelay > 0 || maxDelay > 0
+        val pipelinePostProcessing = sharedPreferences.getBoolean(
+            "pipeline_postprocessing",
+            true,
+        )
+        postProcessingYTDLInstances.clear()
 
         queuedItems.collectLatest { items ->
             if (this@DownloadWorker.isStopped) return@collectLatest
@@ -156,6 +164,7 @@ class DownloadWorker(
             }
 
             val running = ArrayList(runningYTDLInstances)
+            postProcessingYTDLInstances.retainAll(running.toSet())
             val useScheduler = sharedPreferences.getBoolean("use_scheduler", false)
             if (items.isEmpty() && running.isEmpty()) {
                 WorkManager.Companion.getInstance(context).cancelWorkById(this@DownloadWorker.id)
@@ -190,18 +199,30 @@ class DownloadWorker(
                     true,
                 ),
             )
-            // Existing active jobs consume slots first. A lower setting must never
-            // produce a negative value that would make take() throw below.
-            var concurrentDownloads = (downloadLimit - running.size).coerceAtLeast(0)
+            var concurrentDownloads = DownloadPipelinePolicy.availableNetworkSlots(
+                networkLimit = downloadLimit,
+                runningIds = running,
+                postProcessingIds = postProcessingYTDLInstances,
+                pipelineEnabled = pipelinePostProcessing,
+            )
             if (hasDownloadDelay) {
                 concurrentDownloads = (1 - running.size).coerceAtLeast(0)
             }
 
             val eligibleDownloads = if (priorityItemIDs.isNotEmpty()) {
-                val tmp = priorityItemIDs.take(concurrentDownloads)
-                items.filter { it.id !in running && tmp.contains(it.id) }
+                val tmp = priorityItemIDs.asSequence()
+                    .filter { priorityId -> items.any { it.id == priorityId && it.id !in running } }
+                    .take(concurrentDownloads)
+                    .toSet()
+                items.asSequence()
+                    .filter { it.id !in running && it.id in tmp }
+                    .take(concurrentDownloads)
+                    .toList()
             }else{
-                items.take(concurrentDownloads).filter {  it.id !in running }
+                items.asSequence()
+                    .filter { it.id !in running }
+                    .take(concurrentDownloads)
+                    .toList()
             }
 
             eligibleDownloads.forEach{downloadItem ->
@@ -303,6 +324,7 @@ class DownloadWorker(
                             var completedTransientRetries = 0
                             var completedExpiredMediaUrlRetries = 0
                             var response: ExecuteResponse? = null
+                            val postProcessingReported = AtomicBoolean(false)
 
                             // Re-running the original yt-dlp request re-extracts remote URLs
                             // while preserving its output paths, so existing .part data resumes.
@@ -318,6 +340,17 @@ class DownloadWorker(
                                         usingCacheDir = true
                                     ) { progress, _, line ->
                                         attemptOutput.appendLine(line)
+                                        if (pipelinePostProcessing &&
+                                            DownloadPipelinePolicy.isPostProcessingOutput(line) &&
+                                            postProcessingReported.compareAndSet(false, true)
+                                        ) {
+                                            // Wake the observed queue as soon as yt-dlp switches
+                                            // from network I/O to local FFmpeg/post-processing.
+                                            postProcessingYTDLInstances.add(downloadItem.id)
+                                            workerScope.launch {
+                                                dao.notifyActiveDownloadChanged(downloadItem.id)
+                                            }
+                                        }
                                         WorkerEventBus.post(
                                             WorkerProgress(
                                                 progress.toInt(),
@@ -452,6 +485,12 @@ class DownloadWorker(
 
                             response
                         }.onSuccess {
+                            // Scanning and moving output files is local work too, so it
+                            // does not need to occupy a network-download slot.
+                            if (pipelinePostProcessing) {
+                                postProcessingYTDLInstances.add(downloadItem.id)
+                                dao.notifyActiveDownloadChanged(downloadItem.id)
+                            }
                             resultRepo.updateDownloadItem(downloadItem)?.apply {
                                 dao.updateWithoutUpsert(this)
                             }
@@ -639,6 +678,7 @@ class DownloadWorker(
                                 //                            }
 
                                 dao.delete(downloadItem.id)
+                                postProcessingYTDLInstances.remove(downloadItem.id)
 
                                 if (logDownloads) {
                                     logRepo.update(initialLogDetails + it.out, logItem.id, true)
@@ -646,6 +686,7 @@ class DownloadWorker(
                             }
 
                         }.onFailure {
+                            postProcessingYTDLInstances.remove(downloadItem.id)
                             FileUtil.deleteConfigFiles(request)
                             withContext(Dispatchers.Main) {
                                 notificationUtil.cancelDownloadNotification(downloadItem.id.toInt())
@@ -726,6 +767,8 @@ class DownloadWorker(
 
     companion object {
         val runningYTDLInstances: MutableList<Long> = mutableListOf()
+        private val postProcessingYTDLInstances: MutableSet<Long> =
+            ConcurrentHashMap.newKeySet()
         const val TAG = "DownloadWorker"
         private val downloadLock = Mutex()
     }

--- a/app/src/main/java/com/deniscerri/ytdl/work/DownloadWorker.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/work/DownloadWorker.kt
@@ -30,6 +30,8 @@ import com.deniscerri.ytdl.database.repository.DownloadRepository
 import com.deniscerri.ytdl.database.repository.LogRepository
 import com.deniscerri.ytdl.database.repository.ResultRepository
 import com.deniscerri.ytdl.util.AlarmScheduler
+import com.deniscerri.ytdl.util.DeviceResourceMonitor
+import com.deniscerri.ytdl.util.DeviceResourcePolicy
 import com.deniscerri.ytdl.util.Extensions.getMediaDuration
 import com.deniscerri.ytdl.util.Extensions.toStringDuration
 import com.deniscerri.ytdl.util.FileUtil
@@ -49,6 +51,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
@@ -107,6 +110,7 @@ class DownloadWorker(
         val handler = Handler(Looper.getMainLooper())
         val alarmScheduler = AlarmScheduler(context)
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+        val deviceResourceMonitor = DeviceResourceMonitor(context)
         val time = System.currentTimeMillis() + 6000
         val priorityItemIDs = (inputData.getLongArray("priority_item_ids") ?: longArrayOf()).toMutableList()
         val continueAfterPriorityIds = inputData.getBoolean("continue_after_priority_ids", true)
@@ -154,6 +158,22 @@ class DownloadWorker(
         )
         postProcessingYTDLInstances.clear()
 
+        // Resource state changes independently of Room. Wake the queue when pressure
+        // changes so held items resume without requiring a manual database action.
+        workerScope.launch {
+            var previousPressure: DeviceResourcePolicy.Pressure? = null
+            while (isActive) {
+                val pressure = DeviceResourcePolicy.pressure(
+                    deviceResourceMonitor.snapshot(),
+                )
+                if (previousPressure != null && pressure != previousPressure) {
+                    dao.notifyQueuedDownloadsChanged()
+                }
+                previousPressure = pressure
+                delay(15_000L)
+            }
+        }
+
         queuedItems.collectLatest { items ->
             if (this@DownloadWorker.isStopped) return@collectLatest
 
@@ -191,7 +211,7 @@ class DownloadWorker(
                 "max_parallel_requests",
                 DownloadNetworkPolicy.DEFAULT_MAX_PARALLEL_REQUESTS,
             )
-            val downloadLimit = DownloadNetworkPolicy.effectiveDownloadLimit(
+            var downloadLimit = DownloadNetworkPolicy.effectiveDownloadLimit(
                 requestedDownloads = requestedDownloads,
                 maxParallelRequests = maxParallelRequests,
                 budgetingEnabled = sharedPreferences.getBoolean(
@@ -199,12 +219,28 @@ class DownloadWorker(
                     true,
                 ),
             )
+            val protectDevice = sharedPreferences.getBoolean(
+                "device_resource_protection",
+                true,
+            )
+            val devicePressure = if (protectDevice) {
+                DeviceResourcePolicy.pressure(deviceResourceMonitor.snapshot())
+            } else {
+                DeviceResourcePolicy.Pressure.NORMAL
+            }
+            downloadLimit = DeviceResourcePolicy.limitDownloads(
+                downloadLimit,
+                devicePressure,
+            )
+            val pipelineAllowed = pipelinePostProcessing &&
+                (!protectDevice || DeviceResourcePolicy.allowPostProcessingOverlap(devicePressure))
             var concurrentDownloads = DownloadPipelinePolicy.availableNetworkSlots(
-                networkLimit = downloadLimit,
+                networkLimit = downloadLimit.coerceAtLeast(1),
                 runningIds = running,
                 postProcessingIds = postProcessingYTDLInstances,
-                pipelineEnabled = pipelinePostProcessing,
+                pipelineEnabled = pipelineAllowed,
             )
+            if (downloadLimit == 0) concurrentDownloads = 0
             if (hasDownloadDelay) {
                 concurrentDownloads = (1 - running.size).coerceAtLeast(0)
             }
@@ -340,7 +376,7 @@ class DownloadWorker(
                                         usingCacheDir = true
                                     ) { progress, _, line ->
                                         attemptOutput.appendLine(line)
-                                        if (pipelinePostProcessing &&
+                                        if (pipelineAllowed &&
                                             DownloadPipelinePolicy.isPostProcessingOutput(line) &&
                                             postProcessingReported.compareAndSet(false, true)
                                         ) {
@@ -487,7 +523,7 @@ class DownloadWorker(
                         }.onSuccess {
                             // Scanning and moving output files is local work too, so it
                             // does not need to occupy a network-download slot.
-                            if (pipelinePostProcessing) {
+                            if (pipelineAllowed) {
                                 postProcessingYTDLInstances.add(downloadItem.id)
                                 dao.notifyActiveDownloadChanged(downloadItem.id)
                             }

--- a/app/src/main/java/com/deniscerri/ytdl/work/DownloadWorker.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/work/DownloadWorker.kt
@@ -22,6 +22,7 @@ import com.deniscerri.ytdl.App
 import com.deniscerri.ytdl.MainActivity
 import com.deniscerri.ytdl.R
 import com.deniscerri.ytdl.core.RuntimeManager
+import com.deniscerri.ytdl.core.models.ExecuteResponse
 import com.deniscerri.ytdl.database.DBManager
 import com.deniscerri.ytdl.database.models.HistoryItem
 import com.deniscerri.ytdl.database.models.LogItem
@@ -32,9 +33,11 @@ import com.deniscerri.ytdl.util.AlarmScheduler
 import com.deniscerri.ytdl.util.Extensions.getMediaDuration
 import com.deniscerri.ytdl.util.Extensions.toStringDuration
 import com.deniscerri.ytdl.util.FileUtil
+import com.deniscerri.ytdl.util.HttpRetryPolicy
 import com.deniscerri.ytdl.util.NotificationUtil
 import com.deniscerri.ytdl.util.WorkerEventBus
 import com.deniscerri.ytdl.util.extractors.ytdlp.YTDLPUtil
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -276,34 +279,99 @@ class DownloadWorker(
                         }
 
                         runCatching {
-                            RuntimeManager.getInstance().destroyProcessById(downloadItem.id.toString())
-                            RuntimeManager.getInstance().execute(
-                                request = request,
-                                processId = downloadItem.id.toString(),
-                                redirectErrorStream = true,
-                                usingCacheDir = true
-                            ) { progress, _, line ->
-                                WorkerEventBus.post(
-                                    WorkerProgress(
-                                        progress.toInt(),
-                                        line,
-                                        downloadItem.id,
-                                        downloadItem.logID
-                                    )
-                                )
-                                val title: String = downloadItem.title.ifEmpty { downloadItem.url }
-                                notificationUtil.updateDownloadNotification(
-                                    downloadItem.id.toInt(),
-                                    line, progress.toInt(), 0, title,
-                                    NotificationUtil.Companion.DOWNLOAD_SERVICE_CHANNEL_ID
-                                )
-                                CoroutineScope(Dispatchers.IO).launch {
-                                    if (logDownloads) {
-                                        logRepo.update(line, logItem.id)
+                            var completedTransientRetries = 0
+                            var completedExpiredMediaUrlRetries = 0
+                            var response: ExecuteResponse? = null
+
+                            // Re-running the original yt-dlp request re-extracts remote URLs
+                            // while preserving its output paths, so existing .part data resumes.
+                            while (response == null) {
+                                val attemptOutput = StringBuilder()
+                                try {
+                                    RuntimeManager.getInstance()
+                                        .destroyProcessById(downloadItem.id.toString())
+                                    response = RuntimeManager.getInstance().execute(
+                                        request = request,
+                                        processId = downloadItem.id.toString(),
+                                        redirectErrorStream = true,
+                                        usingCacheDir = true
+                                    ) { progress, _, line ->
+                                        attemptOutput.appendLine(line)
+                                        WorkerEventBus.post(
+                                            WorkerProgress(
+                                                progress.toInt(),
+                                                line,
+                                                downloadItem.id,
+                                                downloadItem.logID
+                                            )
+                                        )
+                                        val title: String =
+                                            downloadItem.title.ifEmpty { downloadItem.url }
+                                        notificationUtil.updateDownloadNotification(
+                                            downloadItem.id.toInt(),
+                                            line, progress.toInt(), 0, title,
+                                            NotificationUtil.Companion.DOWNLOAD_SERVICE_CHANNEL_ID
+                                        )
+                                        CoroutineScope(Dispatchers.IO).launch {
+                                            if (logDownloads) {
+                                                logRepo.update(line, logItem.id)
+                                            }
+                                            logString.append("$line\n")
+                                        }
                                     }
-                                    logString.append("$line\n")
+                                } catch (error: Exception) {
+                                    if (this@DownloadWorker.isStopped ||
+                                        error is RuntimeManager.CanceledException
+                                    ) {
+                                        throw error
+                                    }
+
+                                    val failureOutput = buildString {
+                                        append(attemptOutput)
+                                        appendLine()
+                                        append(error.message.orEmpty())
+                                    }
+                                    val retry = HttpRetryPolicy.nextRetry(
+                                        output = failureOutput,
+                                        completedTransientRetries = completedTransientRetries,
+                                        completedExpiredMediaUrlRetries =
+                                            completedExpiredMediaUrlRetries,
+                                    ) ?: throw error
+
+                                    when (retry.reason) {
+                                        HttpRetryPolicy.Reason.TRANSIENT_HTTP ->
+                                            completedTransientRetries += 1
+                                        HttpRetryPolicy.Reason.EXPIRED_MEDIA_URL ->
+                                            completedExpiredMediaUrlRetries += 1
+                                    }
+
+                                    val retryMessage = context.getString(
+                                        R.string.http_recovery_retry,
+                                        retry.statusCode,
+                                        retry.delaySeconds,
+                                    )
+                                    logString.appendLine(retryMessage)
+                                    WorkerEventBus.post(
+                                        WorkerProgress(
+                                            0,
+                                            retryMessage,
+                                            downloadItem.id,
+                                            downloadItem.logID,
+                                        ),
+                                    )
+                                    notificationUtil.updateDownloadNotification(
+                                        downloadItem.id.toInt(),
+                                        retryMessage,
+                                        0,
+                                        0,
+                                        downloadItem.title.ifEmpty { downloadItem.url },
+                                        NotificationUtil.Companion.DOWNLOAD_SERVICE_CHANNEL_ID,
+                                    )
+                                    delay(retry.delaySeconds * 1000)
                                 }
                             }
+
+                            response
                         }.onSuccess {
                             resultRepo.updateDownloadItem(downloadItem)?.apply {
                                 dao.updateWithoutUpsert(this)
@@ -505,6 +573,7 @@ class DownloadWorker(
                             }
                             if (this@DownloadWorker.isStopped) return@onFailure
                             if (it is RuntimeManager.CanceledException) return@onFailure
+                            if (it is CancellationException) return@onFailure
                             if (it.message?.contains("JSONDecodeError") == true) {
                                 val cachePath = FileUtil.getInfoJsonPath(context)
                                 val infoJsonName = MessageDigest.getInstance("MD5")

--- a/app/src/main/java/com/deniscerri/ytdl/work/DownloadWorker.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/work/DownloadWorker.kt
@@ -32,6 +32,7 @@ import com.deniscerri.ytdl.database.repository.ResultRepository
 import com.deniscerri.ytdl.util.AlarmScheduler
 import com.deniscerri.ytdl.util.DeviceResourceMonitor
 import com.deniscerri.ytdl.util.DeviceResourcePolicy
+import com.deniscerri.ytdl.util.DownloadConnectivityMonitor
 import com.deniscerri.ytdl.util.Extensions.getMediaDuration
 import com.deniscerri.ytdl.util.Extensions.toStringDuration
 import com.deniscerri.ytdl.util.FileUtil
@@ -51,6 +52,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -111,6 +114,7 @@ class DownloadWorker(
         val alarmScheduler = AlarmScheduler(context)
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
         val deviceResourceMonitor = DeviceResourceMonitor(context)
+        val connectivityMonitor = DownloadConnectivityMonitor.getInstance(context)
         val time = System.currentTimeMillis() + 6000
         val priorityItemIDs = (inputData.getLongArray("priority_item_ids") ?: longArrayOf()).toMutableList()
         val continueAfterPriorityIds = inputData.getBoolean("continue_after_priority_ids", true)
@@ -157,6 +161,19 @@ class DownloadWorker(
             true,
         )
         postProcessingYTDLInstances.clear()
+
+        // Connectivity changes independently of Room. Wake queued downloads when a
+        // validated connection disappears or returns.
+        workerScope.launch {
+            var firstState = true
+            connectivityMonitor.isOnline.collectLatest {
+                if (firstState) {
+                    firstState = false
+                } else {
+                    dao.notifyQueuedDownloadsChanged()
+                }
+            }
+        }
 
         // Resource state changes independently of Room. Wake the queue when pressure
         // changes so held items resume without requiring a manual database action.
@@ -243,6 +260,11 @@ class DownloadWorker(
             if (downloadLimit == 0) concurrentDownloads = 0
             if (hasDownloadDelay) {
                 concurrentDownloads = (1 - running.size).coerceAtLeast(0)
+            }
+            if (sharedPreferences.getBoolean("connectivity_aware_downloads", true) &&
+                !connectivityMonitor.isOnline.value
+            ) {
+                concurrentDownloads = 0
             }
 
             val eligibleDownloads = if (priorityItemIDs.isNotEmpty()) {
@@ -361,14 +383,50 @@ class DownloadWorker(
                             var completedExpiredMediaUrlRetries = 0
                             var response: ExecuteResponse? = null
                             val postProcessingReported = AtomicBoolean(false)
+                            val connectivityAware = sharedPreferences.getBoolean(
+                                "connectivity_aware_downloads",
+                                true,
+                            )
 
                             // Re-running the original yt-dlp request re-extracts remote URLs
                             // while preserving its output paths, so existing .part data resumes.
                             while (response == null) {
+                                if (connectivityAware && !connectivityMonitor.isOnline.value) {
+                                    val waitingMessage = context.getString(R.string.waiting_for_network)
+                                    WorkerEventBus.post(
+                                        WorkerProgress(
+                                            0,
+                                            waitingMessage,
+                                            downloadItem.id,
+                                            downloadItem.logID,
+                                        ),
+                                    )
+                                    notificationUtil.updateDownloadNotification(
+                                        downloadItem.id.toInt(),
+                                        waitingMessage,
+                                        0,
+                                        0,
+                                        downloadItem.title.ifEmpty { downloadItem.url },
+                                        NotificationUtil.Companion.DOWNLOAD_SERVICE_CHANNEL_ID,
+                                    )
+                                    connectivityMonitor.awaitOnline()
+                                }
+
                                 val attemptOutput = StringBuilder()
+                                val networkInterrupted = AtomicBoolean(false)
+                                RuntimeManager.getInstance()
+                                    .destroyProcessById(downloadItem.id.toString())
+                                val connectivityWatcher = if (connectivityAware) {
+                                    workerScope.launch {
+                                        connectivityMonitor.isOnline.filter { !it }.first()
+                                        networkInterrupted.set(true)
+                                        RuntimeManager.getInstance()
+                                            .destroyProcessById(downloadItem.id.toString())
+                                    }
+                                } else {
+                                    null
+                                }
                                 try {
-                                    RuntimeManager.getInstance()
-                                        .destroyProcessById(downloadItem.id.toString())
                                     response = RuntimeManager.getInstance().execute(
                                         request = request,
                                         processId = downloadItem.id.toString(),
@@ -410,11 +468,28 @@ class DownloadWorker(
                                         }
                                     }
                                 } catch (error: Exception) {
-                                    if (this@DownloadWorker.isStopped ||
-                                        error is RuntimeManager.CanceledException
-                                    ) {
+                                    if (this@DownloadWorker.isStopped) {
                                         throw error
                                     }
+                                    if (connectivityAware &&
+                                        (networkInterrupted.get() || !connectivityMonitor.isOnline.value)
+                                    ) {
+                                        postProcessingYTDLInstances.remove(downloadItem.id)
+                                        postProcessingReported.set(false)
+                                        val waitingMessage = context.getString(R.string.waiting_for_network)
+                                        logString.appendLine(waitingMessage)
+                                        WorkerEventBus.post(
+                                            WorkerProgress(
+                                                0,
+                                                waitingMessage,
+                                                downloadItem.id,
+                                                downloadItem.logID,
+                                            ),
+                                        )
+                                        connectivityMonitor.awaitOnline()
+                                        continue
+                                    }
+                                    if (error is RuntimeManager.CanceledException) throw error
 
                                     val failureOutput = buildString {
                                         append(attemptOutput)
@@ -516,6 +591,8 @@ class DownloadWorker(
                                     }
 
                                     throw error
+                                } finally {
+                                    connectivityWatcher?.cancel()
                                 }
                             }
 

--- a/app/src/main/java/com/deniscerri/ytdl/work/DownloadWorker.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/work/DownloadWorker.kt
@@ -33,6 +33,7 @@ import com.deniscerri.ytdl.util.AlarmScheduler
 import com.deniscerri.ytdl.util.Extensions.getMediaDuration
 import com.deniscerri.ytdl.util.Extensions.toStringDuration
 import com.deniscerri.ytdl.util.FileUtil
+import com.deniscerri.ytdl.util.DownloadNetworkPolicy
 import com.deniscerri.ytdl.util.HttpRetryPolicy
 import com.deniscerri.ytdl.util.NotificationUtil
 import com.deniscerri.ytdl.util.SubtitleLanguagePolicy
@@ -173,9 +174,27 @@ class DownloadWorker(
                 return@collectLatest
             }
 
-            var concurrentDownloads = sharedPreferences.getInt("concurrent_downloads", 1) - running.size
+            val requestedDownloads = sharedPreferences.getInt(
+                "concurrent_downloads",
+                DownloadNetworkPolicy.DEFAULT_CONCURRENT_DOWNLOADS,
+            )
+            val maxParallelRequests = sharedPreferences.getInt(
+                "max_parallel_requests",
+                DownloadNetworkPolicy.DEFAULT_MAX_PARALLEL_REQUESTS,
+            )
+            val downloadLimit = DownloadNetworkPolicy.effectiveDownloadLimit(
+                requestedDownloads = requestedDownloads,
+                maxParallelRequests = maxParallelRequests,
+                budgetingEnabled = sharedPreferences.getBoolean(
+                    "smart_request_budget",
+                    true,
+                ),
+            )
+            // Existing active jobs consume slots first. A lower setting must never
+            // produce a negative value that would make take() throw below.
+            var concurrentDownloads = (downloadLimit - running.size).coerceAtLeast(0)
             if (hasDownloadDelay) {
-                concurrentDownloads = 1 - running.size
+                concurrentDownloads = (1 - running.size).coerceAtLeast(0)
             }
 
             val eligibleDownloads = if (priorityItemIDs.isNotEmpty()) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,12 @@
     <string name="adjust_video">Adjust video</string>
     <string name="concurrent_downloads">Concurrent downloads</string>
     <string name="concurrent_downloads_summary">Number of downloads executing at the same time</string>
+    <string name="action_required_open_app">Action required — open YTDLnis</string>
+    <string name="subtitle_download_failed">Subtitles couldn’t be downloaded</string>
+    <string name="subtitle_failure_decision_message">The media download can continue without subtitles. Choose Continue to remove subtitle options, Retry to try subtitles again, or Cancel to stop this item.</string>
+    <string name="continue_download">Continue</string>
+    <string name="retry">Retry</string>
+    <string name="continuing_without_subtitles">Continuing without subtitles after your confirmation.</string>
     <string name="defaultValue">Default</string>
     <string name="container">Container</string>
     <string name="template">Template</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,6 +117,8 @@
     <string name="max_parallel_requests_summary">Upper connection limit shared by active downloads and media fragments</string>
     <string name="pipeline_postprocessing">Pipeline downloads and FFmpeg</string>
     <string name="pipeline_postprocessing_summary">Start the next network download while one completed item is being merged or converted locally</string>
+    <string name="device_resource_protection">CPU and temperature protection</string>
+    <string name="device_resource_protection_summary">Reduce transfer concurrency and FFmpeg overlap while the device is busy or hot</string>
     <string name="action_required_open_app">Action required — open YTDLnis</string>
     <string name="subtitle_download_failed">Subtitles couldn’t be downloaded</string>
     <string name="subtitle_failure_decision_message">The media download can continue without subtitles. Choose Continue to remove subtitle options, Retry to try subtitles again, or Cancel to stop this item.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,9 @@
     <string name="pipeline_postprocessing_summary">Start the next network download while one completed item is being merged or converted locally</string>
     <string name="device_resource_protection">CPU and temperature protection</string>
     <string name="device_resource_protection_summary">Reduce transfer concurrency and FFmpeg overlap while the device is busy or hot</string>
+    <string name="connectivity_aware_downloads">Connectivity-aware downloads</string>
+    <string name="connectivity_aware_downloads_summary">Pause safely when validated internet access is lost, preserve partial files, and resume when the connection returns</string>
+    <string name="waiting_for_network">Waiting for a validated internet connection…</string>
     <string name="action_required_open_app">Action required — open YTDLnis</string>
     <string name="subtitle_download_failed">Subtitles couldn’t be downloaded</string>
     <string name="subtitle_failure_decision_message">The media download can continue without subtitles. Choose Continue to remove subtitle options, Retry to try subtitles again, or Cancel to stop this item.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -578,4 +578,5 @@
     <plurals name="every_days"><item quantity="one">Every day</item><item quantity="other">Every %d days</item></plurals>
     <plurals name="every_weeks"><item quantity="one">Every week</item><item quantity="other">Every %d weeks</item></plurals>
     <plurals name="every_months"><item quantity="one">Every month</item><item quantity="other">Every %d months</item></plurals>
+    <string name="http_recovery_retry">HTTP %1$d was temporary. Retrying in %2$d seconds…</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,10 @@
     <string name="adjust_video">Adjust video</string>
     <string name="concurrent_downloads">Concurrent downloads</string>
     <string name="concurrent_downloads_summary">Number of downloads executing at the same time</string>
+    <string name="smart_request_budget">Balance parallel requests</string>
+    <string name="smart_request_budget_summary">Share one connection budget between simultaneous downloads and their media fragments</string>
+    <string name="max_parallel_requests">Maximum parallel requests</string>
+    <string name="max_parallel_requests_summary">Upper connection limit shared by active downloads and media fragments</string>
     <string name="action_required_open_app">Action required — open YTDLnis</string>
     <string name="subtitle_download_failed">Subtitles couldn’t be downloaded</string>
     <string name="subtitle_failure_decision_message">The media download can continue without subtitles. Choose Continue to remove subtitle options, Retry to try subtitles again, or Cancel to stop this item.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,8 @@
     <string name="smart_request_budget_summary">Share one connection budget between simultaneous downloads and their media fragments</string>
     <string name="max_parallel_requests">Maximum parallel requests</string>
     <string name="max_parallel_requests_summary">Upper connection limit shared by active downloads and media fragments</string>
+    <string name="pipeline_postprocessing">Pipeline downloads and FFmpeg</string>
+    <string name="pipeline_postprocessing_summary">Start the next network download while one completed item is being merged or converted locally</string>
     <string name="action_required_open_app">Action required — open YTDLnis</string>
     <string name="subtitle_download_failed">Subtitles couldn’t be downloaded</string>
     <string name="subtitle_failure_decision_message">The media download can continue without subtitles. Choose Continue to remove subtitle options, Retry to try subtitles again, or Cancel to stop this item.</string>

--- a/app/src/main/res/xml/downloading_preferences.xml
+++ b/app/src/main/res/xml/downloading_preferences.xml
@@ -143,6 +143,16 @@
             app:summary="@string/pipeline_postprocessing_summary"
             app:title="@string/pipeline_postprocessing" />
 
+        <!-- Lower parallel work automatically when Android thermal state, battery
+             temperature, or normalized CPU load indicates device pressure. -->
+        <SwitchPreferenceCompat
+            android:icon="@drawable/ic_speed"
+            android:key="device_resource_protection"
+            android:widgetLayout="@layout/preferece_material_switch"
+            app:defaultValue="true"
+            app:summary="@string/device_resource_protection_summary"
+            app:title="@string/device_resource_protection" />
+
         <SeekBarPreference
             android:defaultValue="8"
             android:icon="@drawable/ic_speed"

--- a/app/src/main/res/xml/downloading_preferences.xml
+++ b/app/src/main/res/xml/downloading_preferences.xml
@@ -133,6 +133,16 @@
             app:summary="@string/smart_request_budget_summary"
             app:title="@string/smart_request_budget" />
 
+        <!-- The active .part file is never processed; only a completed item may
+             overlap the next network transfer during local FFmpeg work. -->
+        <SwitchPreferenceCompat
+            android:icon="@drawable/ic_concurrent_downloads"
+            android:key="pipeline_postprocessing"
+            android:widgetLayout="@layout/preferece_material_switch"
+            app:defaultValue="true"
+            app:summary="@string/pipeline_postprocessing_summary"
+            app:title="@string/pipeline_postprocessing" />
+
         <SeekBarPreference
             android:defaultValue="8"
             android:icon="@drawable/ic_speed"

--- a/app/src/main/res/xml/downloading_preferences.xml
+++ b/app/src/main/res/xml/downloading_preferences.xml
@@ -153,6 +153,16 @@
             app:summary="@string/device_resource_protection_summary"
             app:title="@string/device_resource_protection" />
 
+        <!-- Stop the active process on local network loss, preserve its .part data,
+             and resume only after Android validates the restored connection. -->
+        <SwitchPreferenceCompat
+            android:icon="@drawable/ic_speed"
+            android:key="connectivity_aware_downloads"
+            android:widgetLayout="@layout/preferece_material_switch"
+            app:defaultValue="true"
+            app:summary="@string/connectivity_aware_downloads_summary"
+            app:title="@string/connectivity_aware_downloads" />
+
         <SeekBarPreference
             android:defaultValue="8"
             android:icon="@drawable/ic_speed"

--- a/app/src/main/res/xml/downloading_preferences.xml
+++ b/app/src/main/res/xml/downloading_preferences.xml
@@ -103,8 +103,10 @@
             android:key="last_used_download_type"
             app:isPreferenceVisible="false" />
 
+        <!-- Balanced defaults improve throughput without starting an aggressive
+             number of connections on a typical mobile network. -->
         <SeekBarPreference
-            android:defaultValue="1"
+            android:defaultValue="4"
             android:icon="@drawable/ic_lines"
             android:max="25"
             app:key="concurrent_fragments"
@@ -114,7 +116,7 @@
             app:title="@string/concurrent_fragments" />
 
         <SeekBarPreference
-            android:defaultValue="1"
+            android:defaultValue="2"
             android:icon="@drawable/ic_concurrent_downloads"
             android:max="10"
             app:key="concurrent_downloads"
@@ -122,6 +124,24 @@
             app:showSeekBarValue="true"
             app:summary="@string/concurrent_downloads_summary"
             app:title="@string/concurrent_downloads" />
+
+        <SwitchPreferenceCompat
+            android:icon="@drawable/ic_speed"
+            android:key="smart_request_budget"
+            android:widgetLayout="@layout/preferece_material_switch"
+            app:defaultValue="true"
+            app:summary="@string/smart_request_budget_summary"
+            app:title="@string/smart_request_budget" />
+
+        <SeekBarPreference
+            android:defaultValue="8"
+            android:icon="@drawable/ic_speed"
+            android:max="24"
+            app:key="max_parallel_requests"
+            app:min="2"
+            app:showSeekBarValue="true"
+            app:summary="@string/max_parallel_requests_summary"
+            app:title="@string/max_parallel_requests" />
 
         <EditTextPreference
             android:icon="@drawable/ic_limitrate"

--- a/app/src/main/res/xml/processing_preferences.xml
+++ b/app/src/main/res/xml/processing_preferences.xml
@@ -190,7 +190,7 @@
             android:icon="@drawable/baseline_subject_24"
             app:key="subs_lang"
             app:useSimpleSummaryProvider="true"
-            app:defaultValue="en.*,.*-orig"
+            app:defaultValue="en,.*-orig"
             app:title="@string/subtitle_languages" />
 
 

--- a/app/src/test/java/com/deniscerri/ytdl/core/models/YTDLOptionsTest.kt
+++ b/app/src/test/java/com/deniscerri/ytdl/core/models/YTDLOptionsTest.kt
@@ -1,0 +1,34 @@
+package com.deniscerri.ytdl.core.models
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class YTDLOptionsTest {
+    @Test
+    fun appendsAriaCertificateWithoutDuplicatingItOnRetry() {
+        val options = YTDLOptions()
+            .addOption("--downloader-args", "aria2c:-x4 -s4")
+
+        assertTrue(
+            options.appendToArgument(
+                "--downloader-args",
+                "aria2c:",
+                "--ca-certificate=/cert.pem",
+            ),
+        )
+        assertTrue(
+            options.appendToArgument(
+                "--downloader-args",
+                "aria2c:",
+                "--ca-certificate=/cert.pem",
+            ),
+        )
+        assertFalse(options.appendToArgument("--missing", "aria2c:", "unused"))
+        assertEquals(
+            listOf("--downloader-args", "aria2c:-x4 -s4 --ca-certificate=/cert.pem"),
+            options.buildOptions(),
+        )
+    }
+}

--- a/app/src/test/java/com/deniscerri/ytdl/util/DeviceResourcePolicyTest.kt
+++ b/app/src/test/java/com/deniscerri/ytdl/util/DeviceResourcePolicyTest.kt
@@ -1,0 +1,31 @@
+package com.deniscerri.ytdl.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class DeviceResourcePolicyTest {
+    @Test
+    fun criticalHeatHoldsNewDownloads() {
+        val pressure = DeviceResourcePolicy.pressure(
+            DeviceResourcePolicy.Snapshot(
+                cpuLoadPerCore = 0.1,
+                thermalStatus = 3,
+                batteryTemperatureCelsius = 38f,
+            ),
+        )
+        assertEquals(DeviceResourcePolicy.Pressure.CRITICAL, pressure)
+        assertEquals(0, DeviceResourcePolicy.limitDownloads(4, pressure))
+        assertFalse(DeviceResourcePolicy.allowPostProcessingOverlap(pressure))
+    }
+
+    @Test
+    fun highCpuReducesFragmentsAndSerializesDownloads() {
+        val pressure = DeviceResourcePolicy.pressure(
+            DeviceResourcePolicy.Snapshot(1.2, null, null),
+        )
+        assertEquals(DeviceResourcePolicy.Pressure.HIGH, pressure)
+        assertEquals(1, DeviceResourcePolicy.limitDownloads(4, pressure))
+        assertEquals(2, DeviceResourcePolicy.limitFragments(8, pressure))
+    }
+}

--- a/app/src/test/java/com/deniscerri/ytdl/util/DownloadNetworkPolicyTest.kt
+++ b/app/src/test/java/com/deniscerri/ytdl/util/DownloadNetworkPolicyTest.kt
@@ -1,0 +1,57 @@
+package com.deniscerri.ytdl.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DownloadNetworkPolicyTest {
+    @Test
+    fun `shared budget caps fragments across downloads`() {
+        assertEquals(
+            2,
+            DownloadNetworkPolicy.effectiveFragmentLimit(
+                requestedFragments = 8,
+                requestedDownloads = 3,
+                maxParallelRequests = 8,
+                budgetingEnabled = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `disabled budgeting preserves requested concurrency`() {
+        assertEquals(
+            12,
+            DownloadNetworkPolicy.effectiveFragmentLimit(
+                requestedFragments = 12,
+                requestedDownloads = 4,
+                maxParallelRequests = 8,
+                budgetingEnabled = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `download limit cannot exceed request budget`() {
+        assertEquals(
+            4,
+            DownloadNetworkPolicy.effectiveDownloadLimit(
+                requestedDownloads = 10,
+                maxParallelRequests = 4,
+                budgetingEnabled = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `limits remain positive for invalid stored values`() {
+        assertEquals(
+            1,
+            DownloadNetworkPolicy.effectiveFragmentLimit(
+                requestedFragments = 0,
+                requestedDownloads = 0,
+                maxParallelRequests = 0,
+                budgetingEnabled = true,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/deniscerri/ytdl/util/DownloadPipelinePolicyTest.kt
+++ b/app/src/test/java/com/deniscerri/ytdl/util/DownloadPipelinePolicyTest.kt
@@ -1,0 +1,42 @@
+package com.deniscerri.ytdl.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DownloadPipelinePolicyTest {
+    @Test
+    fun recognizesFfmpegPostProcessingStages() {
+        assertTrue(DownloadPipelinePolicy.isPostProcessingOutput("[Merger] Merging formats"))
+        assertTrue(DownloadPipelinePolicy.isPostProcessingOutput("[ExtractAudio] Destination: song.mp3"))
+        assertFalse(DownloadPipelinePolicy.isPostProcessingOutput("[download] 100% of 10MiB"))
+        assertFalse(DownloadPipelinePolicy.isPostProcessingOutput("[SponsorBlock] Fetching segments"))
+    }
+
+    @Test
+    fun postProcessingReleasesOneNetworkSlot() {
+        assertEquals(
+            1,
+            DownloadPipelinePolicy.availableNetworkSlots(
+                networkLimit = 2,
+                runningIds = listOf(1, 2),
+                postProcessingIds = setOf(1),
+                pipelineEnabled = true,
+            ),
+        )
+    }
+
+    @Test
+    fun pipelineAllowsOnlyOneOverflowProcess() {
+        assertEquals(
+            1,
+            DownloadPipelinePolicy.availableNetworkSlots(
+                networkLimit = 2,
+                runningIds = listOf(1, 2),
+                postProcessingIds = setOf(1, 2),
+                pipelineEnabled = true,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/deniscerri/ytdl/util/HttpRetryPolicyTest.kt
+++ b/app/src/test/java/com/deniscerri/ytdl/util/HttpRetryPolicyTest.kt
@@ -1,0 +1,106 @@
+package com.deniscerri.ytdl.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HttpRetryPolicyTest {
+    @Test
+    fun `retries recognized temporary HTTP and CDN statuses`() {
+        val statuses = listOf(408, 425, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524)
+
+        statuses.forEach { status ->
+            val retry = HttpRetryPolicy.nextRetry(
+                output = "ERROR: HTTP Error $status",
+                completedTransientRetries = 0,
+                completedExpiredMediaUrlRetries = 0,
+            )
+
+            assertEquals(status, retry?.statusCode)
+            assertEquals(HttpRetryPolicy.Reason.TRANSIENT_HTTP, retry?.reason)
+        }
+    }
+
+    @Test
+    fun `does not retry permanent client errors`() {
+        listOf(400, 401, 404, 410).forEach { status ->
+            assertNull(
+                HttpRetryPolicy.nextRetry(
+                    output = "ERROR: HTTP Error $status",
+                    completedTransientRetries = 0,
+                    completedExpiredMediaUrlRetries = 0,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `stops after bounded transient retry budget`() {
+        assertNull(
+            HttpRetryPolicy.nextRetry(
+                output = "ERROR: HTTP Error 503",
+                completedTransientRetries = HttpRetryPolicy.MAX_TRANSIENT_RETRIES,
+                completedExpiredMediaUrlRetries = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `honors bounded Retry-After seconds`() {
+        val retry = HttpRetryPolicy.nextRetry(
+            output = "HTTP Error 429\nRetry-After: 75",
+            completedTransientRetries = 0,
+            completedExpiredMediaUrlRetries = 0,
+        )
+
+        assertEquals(75L, retry?.delaySeconds)
+    }
+
+    @Test
+    fun `refreshes an expired media URL once`() {
+        val output = "ERROR: unable to download video data: HTTP Error 403: Forbidden"
+
+        val retry = HttpRetryPolicy.nextRetry(
+            output = output,
+            completedTransientRetries = 0,
+            completedExpiredMediaUrlRetries = 0,
+        )
+        assertEquals(HttpRetryPolicy.Reason.EXPIRED_MEDIA_URL, retry?.reason)
+        assertNull(
+            HttpRetryPolicy.nextRetry(
+                output = output,
+                completedTransientRetries = 0,
+                completedExpiredMediaUrlRetries =
+                    HttpRetryPolicy.MAX_EXPIRED_MEDIA_URL_RETRIES,
+            ),
+        )
+    }
+
+    @Test
+    fun `does not retry an authentication-related 403`() {
+        val output = "ERROR: Sign in and provide cookies: HTTP Error 403"
+
+        assertNull(
+            HttpRetryPolicy.nextRetry(
+                output = output,
+                completedTransientRetries = 0,
+                completedExpiredMediaUrlRetries = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `uses the last status when output contains earlier retry noise`() {
+        val output = "HTTP Error 503 while retrying\nFinal error: HTTP Error 404"
+
+        assertEquals(404, HttpRetryPolicy.statusCode(output))
+        assertTrue(
+            HttpRetryPolicy.nextRetry(
+                output = output,
+                completedTransientRetries = 0,
+                completedExpiredMediaUrlRetries = 0,
+            ) == null,
+        )
+    }
+}

--- a/app/src/test/java/com/deniscerri/ytdl/util/SubtitleLanguagePolicyTest.kt
+++ b/app/src/test/java/com/deniscerri/ytdl/util/SubtitleLanguagePolicyTest.kt
@@ -1,0 +1,39 @@
+package com.deniscerri.ytdl.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SubtitleLanguagePolicyTest {
+    @Test
+    fun `migrates legacy translation wildcard`() {
+        assertEquals(
+            SubtitleLanguagePolicy.SAFE_DEFAULT,
+            SubtitleLanguagePolicy.normalize(SubtitleLanguagePolicy.LEGACY_DEFAULT),
+        )
+    }
+
+    @Test
+    fun `preserves explicit user selection`() {
+        assertEquals("en,fr", SubtitleLanguagePolicy.normalize("en,fr"))
+    }
+
+    @Test
+    fun `detects optional subtitle failure`() {
+        assertTrue(
+            SubtitleLanguagePolicy.isDownloadFailure(
+                "ERROR: Unable to download video subtitles for 'en-ar': HTTP Error 429",
+            ),
+        )
+    }
+
+    @Test
+    fun `does not classify media failure as subtitle failure`() {
+        assertFalse(
+            SubtitleLanguagePolicy.isDownloadFailure(
+                "ERROR: Unable to download video data: HTTP Error 503",
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Dependency

Depends on #1332.

This PR uses the queued-download notification mechanism introduced by #1332 and runs inside the existing bounded worker-recovery flow.

It transitively depends on #1331 for explicit `.part` continuation and the download/local-processing pipeline.

This commit contains only the additional connectivity monitoring and offline-resume behavior.

## Summary

This PR adds optional connectivity-aware download handling.

When Android loses its validated internet connection, YTDLnis stops starting new transfers and safely interrupts an active network process. Existing `.part` data is preserved while the worker waits for Android to validate a restored connection.

After connectivity returns, the original yt-dlp request is retried and continues from its existing partial data.

## Changes

* Added `DownloadConnectivityMonitor` using Android’s default-network callback.
* Requires both:

  * `NET_CAPABILITY_INTERNET`
  * `NET_CAPABILITY_VALIDATED`
* Added a default-enabled “Connectivity-aware downloads” setting.
* Prevents new queued transfers from starting while the device is offline.
* Watches for connectivity loss during an active yt-dlp execution.
* Stops the active runtime process when the validated connection disappears.
* Displays “Waiting for a validated internet connection…” in download progress and notifications.
* Waits without repeatedly polling the network.
* Restarts the existing request after the connection is restored.
* Preserves `.part` files for continuation.
* Keeps connectivity interruptions separate from HTTP recovery counters.
* Wakes the queued-download observer when connectivity disappears or returns.
* Preserves the existing behavior when connectivity-aware downloads are disabled.

## Reason

A temporary mobile-network or Wi-Fi interruption can currently cause an active item to enter its normal failure path.

Even when reusable `.part` data exists, the user may have to restart the item manually after connectivity returns.

This change distinguishes a confirmed local connectivity loss from a remote HTTP failure. The worker waits for Android to report validated internet access and then continues the same item.

## Safety and limits

* Captive portals or unvalidated networks are not treated as restored internet access.
* Existing partial files are preserved.
* A connectivity interruption does not consume an HTTP retry attempt.
* Manual worker cancellation remains terminal and is not converted into an offline wait.
* The connectivity watcher is cancelled after every execution attempt.
* Disabling the setting restores the previous behavior.
* The implementation does not attempt to bypass server restrictions or HTTP rate limits.

## Tests

Verified on Windows:

```text
:app:testGithubDebugUnitTest
BUILD SUCCESSFUL
```

```text
assembleGithubDebug
BUILD SUCCESSFUL
```

## Manual Android test plan

1. Start downloading a sufficiently large media item.
2. Enable airplane mode while the transfer is active.
3. Confirm the item changes to “Waiting for a validated internet connection…”.
4. Disable airplane mode.
5. Wait for Android to validate the restored connection.
6. Confirm the same item resumes using its existing `.part` data.

## AI disclosure

I used ChatGPT/Codex to help separate this implementation into a focused patch, review the worker cancellation and retry paths, and diagnose Kotlin, Gradle, and Windows test-worker errors.

I manually applied and reviewed the resulting diff, verified the staged file list, ran the unit tests, and built the GitHub debug APK successfully.
