### PR TITLE
Fix terminal crash caused by invalid terminal sizing

### DIFF
--- a/app/src/main/java/com/deniscerri/ytdl/database/viewmodel/TerminalViewModel.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/database/viewmodel/TerminalViewModel.kt
@@ -58,8 +58,9 @@ class TerminalViewModel(private val application: Application) : AndroidViewModel
         session.updateTerminalSessionClient(client)
         terminal.setBackgroundColor(android.graphics.Color.TRANSPARENT)
 
-        val zoom = PreferenceManager.getDefaultSharedPreferences(context)
-            .getFloat("terminal_zoom", 14f).coerceIn(10f, 30f)
+        val storedZoom = PreferenceManager.getDefaultSharedPreferences(context)
+            .getFloat("terminal_zoom", 35f)
+        val zoom = if (storedZoom.isFinite()) storedZoom.coerceIn(10f, 37f) else 35f
         terminal.setTextSize(zoom.toInt())
         terminal.setTypeface(TerminalUtils.typeface)
 

--- a/app/src/main/java/com/deniscerri/ytdl/ui/more/terminal/TerminalFragment.kt
+++ b/app/src/main/java/com/deniscerri/ytdl/ui/more/terminal/TerminalFragment.kt
@@ -67,6 +67,11 @@ class TerminalFragment : Fragment() {
     private lateinit var session : TerminalSession
     private var sessionId: String? = null
 
+    private fun terminalZoom(): Int {
+        val zoom = sharedPreferences.getFloat("terminal_zoom", 35f)
+        return if (zoom.isFinite()) zoom.coerceIn(10f, 37f).toInt() else 35
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -128,7 +133,7 @@ class TerminalFragment : Fragment() {
         slider?.apply {
             valueFrom = 10f
             valueTo = 37f
-            value = sharedPreferences.getFloat("terminal_zoom", 35f)
+            value = terminalZoom().toFloat()
 
             addOnChangeListener { _, value, _ ->
                 terminalView.setTextSize(value.toInt())
@@ -292,8 +297,10 @@ class TerminalFragment : Fragment() {
 
             val termView = view as TerminalView
 
+            if (termView.width <= 0 || termView.height <= 0) return@doOnLayout
+
             termView.setTextSize(
-                sharedPreferences.getFloat("terminal_zoom", 35f).toInt()
+                terminalZoom()
             )
             termView.setTypeface(TerminalUtils.typeface)
 


### PR DESCRIPTION
### Description
Fixes an out-of-memory crash when opening the embedded terminal on some devices, including Pixel 8 Pro.

### Cause
The terminal could attach before valid view dimensions were available or use an invalid persisted zoom value, causing Termux's terminal buffer to calculate an enormous allocation.

### Changes
- Clamp persisted terminal zoom values to a valid finite range.
- Skip terminal attachment until the view has valid dimensions.
- Apply the protection to both terminal session attachment paths.

### Testing
- Kotlin file diagnostics pass.
- Gradle compilation could not complete locally because the environment reports unsupported Java class-file version 69.